### PR TITLE
Bug/53 ci build fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,5 +46,8 @@ workflows:
     jobs:
       - test
       - deploy:
+          filters:
+            branches:
+              only: master
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           key: lookingatyou-{{ checksum "package-lock.json" }}
       - run:
           name: Install npm dependencies
-          command: npm install
+          command: npm ci
       - save_cache:
           key: lookingatyou-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
       - checkout
       - run: sudo pip install awscli --upgrade
       - run: aws --version
+      - run:
+          name: Update npm to use ci command
+          command: sudo npm i -g npm@6.9.0
       - run: npm --version
       - run:
           name: Install dependencies
@@ -43,8 +46,5 @@ workflows:
     jobs:
       - test
       - deploy:
-          filters:
-            branches:
-              only: master
           requires:
             - test


### PR DESCRIPTION
Updated the circleci config file to update the npm to version 6.9.0 in order to use npm ci command. 
The circle ci python docker image with node variant was using npm v5.6.0 which does not support it.