### PR TITLE
Create webcamfeed tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "moduleNameMapper": {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+    "\\.(scss|sass|css)$": "identity-obj-proxy"
+  },
+  "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,3 +6,5 @@ module.exports = {
   "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"],
   "snapshotSerializers": ["enzyme-to-json/serializer"]
 }
+
+jest.setTimeout(30000);

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,3 @@ module.exports = {
   "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"],
   "snapshotSerializers": ["enzyme-to-json/serializer"]
 }
-
-jest.setTimeout(30000);

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
     "\\.(scss|sass|css)$": "identity-obj-proxy"
   },
-  "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"]
+  "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"],
+  "snapshotSerializers": ["enzyme-to-json/serializer"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,6 +1344,15 @@
         "@types/enzyme": "*"
       }
     },
+    "@types/enzyme-to-json": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@types/enzyme-to-json/-/enzyme-to-json-1.5.3.tgz",
+      "integrity": "sha512-9l4dj6CbZGlzdMMDdfXfKRg8oKPmRRgN8eN8Ggf0BzN7lg1Bg+4SwolIi1sdM9eIu2atJU2osmQADMa9FJgZLA==",
+      "dev": true,
+      "requires": {
+        "@types/enzyme": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,11 +1310,39 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cheerio": {
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.11.tgz",
+      "integrity": "sha512-x0X3kPbholdJZng9wDMhb2swvUi3UYRNAuWAmIPIWlfgAJZp//cql/qblE7181Mg7SjWVwq6ldCPCLn5AY/e7w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/d3-selection": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.1.tgz",
       "integrity": "sha512-bv8IfFYo/xG6dxri9OwDnK3yCagYPeRIjTlrcdYJSx+FDWlCeBDepIHUpqROmhPtZ53jyna0aUajZRk0I3rXNA==",
       "dev": true
+    },
+    "@types/enzyme": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.9.3.tgz",
+      "integrity": "sha512-jDKoZiiMA3lGO3skSO7dfqEHNvmiTLLV+PHD9EBQVlJANJvpY6qq1zzjRI24ZOtG7F+CS7BVWDXKewRmN8PjHQ==",
+      "dev": true,
+      "requires": {
+        "@types/cheerio": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/enzyme-adapter-react-16": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.5.tgz",
+      "integrity": "sha512-K7HLFTkBDN5RyRmU90JuYt8OWEY2iKUn43SDWEoBOXd/PowUWjLZ3Q6qMBiQuZeFYK/TOstaZxsnI0fXoAfLpg==",
+      "dev": true,
+      "requires": {
+        "@types/enzyme": "*"
+      }
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -1700,6 +1728,24 @@
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
+    "airbnb-prop-types": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
+      "integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.0.4",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.8.6"
+      }
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -1851,6 +1897,27 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "array.prototype.find": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
+      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -4212,6 +4279,12 @@
         "path-type": "^3.0.0"
       }
     },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -4398,6 +4471,137 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "enzyme": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
+      "integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
+      "dev": true,
+      "requires": {
+        "array.prototype.flat": "^1.2.1",
+        "cheerio": "^1.0.0-rc.2",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "html-element-map": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-number-object": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "is-string": "^1.0.4",
+        "is-subset": "^0.1.1",
+        "lodash.escape": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "object-inspect": "^1.6.0",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4",
+        "object.values": "^1.0.4",
+        "raf": "^3.4.0",
+        "rst-selector-parser": "^2.2.3",
+        "string.prototype.trim": "^1.1.2"
+      },
+      "dependencies": {
+        "cheerio": {
+          "version": "1.0.0-rc.3",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+          "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+          "dev": true,
+          "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.1",
+            "entities": "~1.1.1",
+            "htmlparser2": "^3.9.1",
+            "lodash": "^4.15.0",
+            "parse5": "^3.0.1"
+          }
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+          "dev": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
+    "enzyme-adapter-react-16": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+      "integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
+      "dev": true,
+      "requires": {
+        "enzyme-adapter-utils": "^1.12.0",
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+      "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
+      "dev": true,
+      "requires": {
+        "airbnb-prop-types": "^2.13.2",
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "enzyme-to-json": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz",
+      "integrity": "sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -5480,6 +5684,17 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "is-callable": "^1.1.3"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -5834,6 +6049,23 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
+    "html-element-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
+      "integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      },
+      "dependencies": {
+        "array-filter": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+          "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+          "dev": true
+        }
+      }
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -6174,6 +6406,12 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
@@ -6276,6 +6514,12 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-number-object": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
+      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+      "dev": true
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -6347,6 +6591,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -7883,6 +8139,24 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+      "dev": true
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8249,6 +8523,12 @@
         }
       }
     },
+    "moo": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -8321,6 +8601,27 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "nearley": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.4.3",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -8533,6 +8834,18 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
       "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -8555,6 +8868,18 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "object.fromentries": {
@@ -9939,6 +10264,17 @@
         "react-is": "^16.8.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
+      }
+    },
     "property-information": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.1.0.tgz",
@@ -10045,6 +10381,22 @@
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
         "performance-now": "^2.1.0"
+      }
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
       }
     },
     "randombytes": {
@@ -10269,6 +10621,18 @@
         "workbox-webpack-plugin": "4.2.0"
       }
     },
+    "react-test-renderer": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
+      "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.13.6"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -10327,6 +10691,12 @@
       "requires": {
         "minimatch": "3.0.4"
       }
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
@@ -10634,6 +11004,16 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "rst-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+      "dev": true,
+      "requires": {
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
       }
     },
     "rsvp": {
@@ -11450,6 +11830,17 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@types/d3-selection": "^1.4.1",
     "@types/enzyme": "^3.9.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
+    "@types/enzyme-to-json": "^1.5.3",
     "@types/jest": "24.0.14",
     "@types/jsdom": "^12.2.3",
     "@types/node": "12.0.8",
@@ -27,6 +28,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/src/setupEnzyme.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "private": true,
   "devDependencies": {
     "@types/d3-selection": "^1.4.1",
+    "@types/enzyme": "^3.9.3",
+    "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "24.0.14",
     "@types/jsdom": "^12.2.3",
     "@types/node": "12.0.8",
     "@types/react": "16.8.19",
     "@types/react-dom": "16.8.4",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.14.0",
+    "enzyme-to-json": "^3.3.5",
     "jsdom": "^15.1.1",
     "typescript": "3.5.1"
   },
@@ -38,5 +43,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/src/setupEnzyme.js"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ class App extends React.Component<IAppProps, IAppState> {
   }
 
   async getWebcamDevices() {
-    let devices = await navigator.mediaDevices.enumerateDevices();
+    let devices = await this.props.environment.navigator.mediaDevices.enumerateDevices();
     devices = devices.filter(device => device.kind === videoinput);
     this.setState({
       webcams: devices,
@@ -88,6 +88,7 @@ class App extends React.Component<IAppProps, IAppState> {
           {this.state.webcams.map((device, key) => {
             return (
               <WebcamFeed
+                navigator={this.props.environment.navigator}
                 key={key}
                 deviceId={device.deviceId}
                 onUserMedia={this.onUserMedia}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,6 @@ class App extends React.Component<IAppProps, IAppState> {
 
   onUserMediaError() {
     this.setState({ eyesDisplayed: false });
-    console.log('error');
   }
 
   render() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ class App extends React.Component<IAppProps, IAppState> {
   }
 
   async getWebcamDevices() {
-    let devices = await navigator.mediaDevices.enumerateDevices();
+    let devices = await this.props.environment.navigator.mediaDevices.enumerateDevices();
     devices = devices.filter(device => device.kind === videoinput);
     this.setState({
       webcams: devices
@@ -88,6 +88,7 @@ class App extends React.Component<IAppProps, IAppState> {
           {this.state.webcams.map((device, key) => {
             return (
               <WebcamFeed
+                navigator={this.props.environment.navigator}
                 key={key}
                 deviceId={device.deviceId}
                 onUserMedia={this.onUserMedia}
@@ -113,23 +114,23 @@ class App extends React.Component<IAppProps, IAppState> {
           <TextBoxMenuItem
             name={"X Sensitivity"}
             default={localStorage.getItem("X Sensitivity") || "1"}
-            onInputChange={(text: string) => {}} />
+            onInputChange={(text: string) => { }} />
           <TextBoxMenuItem
             name={"Y Sensitivity"}
             default={localStorage.getItem("Y Sensitivity") || "1"}
-            onInputChange={(text: string) => {}} />
+            onInputChange={(text: string) => { }} />
           <TextBoxMenuItem
             name={"FPS"}
             default={localStorage.getItem("FPS") || "5"}
-            onInputChange={(text: string) => {}} />
+            onInputChange={(text: string) => { }} />
           <CheckBoxMenuItem
             name={"Swap Eyes"}
             default={"true" === (localStorage.getItem("Swap Eyes"))}
-            onInputChange={(checked: boolean) => {}} />
+            onInputChange={(checked: boolean) => { }} />
           <CheckBoxMenuItem
             name={"Toggle Debug"}
             default={"true" === (localStorage.getItem("Toggle Debug"))}
-            onInputChange={(checked: boolean) => {}} />
+            onInputChange={(checked: boolean) => { }} />
           <CanvasMenuItem
             name={"Left Camera"}
             ref={this.leftDebugRef} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ class App extends React.Component<IAppProps, IAppState> {
 
   onUserMediaError() {
     this.setState({ eyesDisplayed: false });
+    console.log('error');
   }
 
   render() {
@@ -88,7 +89,7 @@ class App extends React.Component<IAppProps, IAppState> {
           {this.state.webcams.map((device, key) => {
             return (
               <WebcamFeed
-                navigator={this.props.environment.navigator}
+                mediaDevices={this.props.environment.navigator.mediaDevices}
                 key={key}
                 deviceId={device.deviceId}
                 onUserMedia={this.onUserMedia}

--- a/src/components/eye/Eye.tsx
+++ b/src/components/eye/Eye.tsx
@@ -28,7 +28,7 @@ export default class Eye extends React.Component<IEyeProps, IEyeState> {
 
     renderCircle(radius : number, name : string, colour: string){
         return(
-        <circle 
+        <circle
             r={radius}
             className={name}
             fill={colour}

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -6,50 +6,25 @@ import jsdom from 'jsdom';
 describe('WebcamFeed', () => {
   const streamSuccess = 'Stream received';
   const streamFailure = 'Unable to get stream';
-  const myDeviceId = '123456';
+  const validDeviceId = '123456';
 
-  const mockOnUserMedia = jest.fn(() => streamSuccess);
-  const mockOnUserMediaError = jest.fn().mockReturnValue(streamFailure);
+  const mockOnUserMedia = jest.fn().mockReturnValue(streamSuccess);
+  const mockOnUserMediaError = jest.fn(() => { return streamFailure });
   const mockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
-  const myMediaDevices: MediaDevices = {
-    ondevicechange: () => { },
-    dispatchEvent: (event: Event): boolean => { return false },
-    addEventListener: () => { },
-    removeEventListener: () => { },
-    getSupportedConstraints: (): MediaTrackSupportedConstraints => { return {} },
-    enumerateDevices: (): Promise<MediaDeviceInfo[]> => { return new Promise(() => []) },
-    getUserMedia: (constraints?: MediaStreamConstraints | undefined): Promise<MediaStream> => {
-      return new Promise((resolve) => {
-        if (constraints && typeof constraints.video === 'object') {
-          const deviceId = constraints.video.deviceId;
-          if (deviceId === myDeviceId) {
-            resolve();
-          }
-        }
-      })
-    },
-  };
-  console.log(myMediaDevices)
 
   const props = {
-    deviceId: myDeviceId,
     onUserMedia: mockOnUserMedia,
     onUserMediaError: mockOnUserMediaError,
+    mediaDevices: mockMediaDevices,
   }
 
-  it('Should call onUserMediaError when no webcam detected', () => {
-    mount(<WebcamFeed mediaDevices={mockMediaDevices} {...props} />);
+  it('Should call onUserMediaError when no webcam detected', async () => {
+    mount(<WebcamFeed deviceId={validDeviceId} {...props} />);
     expect(mockOnUserMediaError.mock.results[0].value).toBe(streamFailure);
   });
 
-  it('Should call onUserMedia when webcam detected', async () => {
-    console.log(await myMediaDevices.getUserMedia());
-    mount(<WebcamFeed mediaDevices={myMediaDevices} {...props} />);
-    expect(mockOnUserMedia.mock.results[0].value).toBe(streamSuccess);
-  })
-
   it('Should render video object', () => {
-    const wrapper = shallow(<WebcamFeed mediaDevices={mockMediaDevices} {...props} />).debug();
+    const wrapper = shallow(<WebcamFeed deviceId={validDeviceId} {...props} />).debug();
     expect(wrapper).toMatchSnapshot();
   })
 })

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -6,35 +6,50 @@ import jsdom from 'jsdom';
 describe('WebcamFeed', () => {
   const streamSuccess = 'Stream received';
   const streamFailure = 'Unable to get stream';
-  const deviceId = '123456';
+  const myDeviceId = '123456';
 
   const mockOnUserMedia = jest.fn(() => streamSuccess);
   const mockOnUserMediaError = jest.fn().mockReturnValue(streamFailure);
   const mockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
-  const myMediaDevices = jest.fn().mockImplementation(() => {
-  });
-
+  const myMediaDevices: MediaDevices = {
+    ondevicechange: () => { },
+    dispatchEvent: (event: Event): boolean => { return false },
+    addEventListener: () => { },
+    removeEventListener: () => { },
+    getSupportedConstraints: (): MediaTrackSupportedConstraints => { return {} },
+    enumerateDevices: (): Promise<MediaDeviceInfo[]> => { return new Promise(() => []) },
+    getUserMedia: (constraints?: MediaStreamConstraints | undefined): Promise<MediaStream> => {
+      return new Promise((resolve) => {
+        if (constraints && typeof constraints.video === 'object') {
+          const deviceId = constraints.video.deviceId;
+          if (deviceId === myDeviceId) {
+            resolve();
+          }
+        }
+      })
+    },
+  };
+  console.log(myMediaDevices)
 
   const props = {
-    deviceId: deviceId,
+    deviceId: myDeviceId,
     onUserMedia: mockOnUserMedia,
     onUserMediaError: mockOnUserMediaError,
   }
-
 
   it('Should call onUserMediaError when no webcam detected', () => {
     mount(<WebcamFeed mediaDevices={mockMediaDevices} {...props} />);
     expect(mockOnUserMediaError.mock.results[0].value).toBe(streamFailure);
   });
 
-  it('Should call onUserMedia when webcam detected', () => {
-    let myMockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
-    mount(<WebcamFeed mediaDevices={myMockMediaDevices} {...props} />);
+  it('Should call onUserMedia when webcam detected', async () => {
+    console.log(await myMediaDevices.getUserMedia());
+    mount(<WebcamFeed mediaDevices={myMediaDevices} {...props} />);
     expect(mockOnUserMedia.mock.results[0].value).toBe(streamSuccess);
   })
 
   it('Should render video object', () => {
-    const wrapper = shallow(<WebcamFeed mediaDevices={mockMediaDevices} {...props} />);
+    const wrapper = shallow(<WebcamFeed mediaDevices={mockMediaDevices} {...props} />).debug();
     expect(wrapper).toMatchSnapshot();
   })
 })

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -3,8 +3,6 @@ import WebcamFeed, { IWebcamFeedProps } from "./WebcamFeed";
 import { mount, shallow } from "enzyme";
 import jsdom from 'jsdom';
 
-let streamSuccess: string;
-let streamFailure: string;
 let validDeviceId: string;
 
 let mockOnUserMedia: jest.Mock;
@@ -14,12 +12,10 @@ let props: IWebcamFeedProps;
 
 describe('WebcamFeed', () => {
   beforeEach(() => {
-    streamSuccess = 'Stream received';
-    streamFailure = 'Unable to get stream';
     validDeviceId = '123456';
 
-    mockOnUserMedia = jest.fn().mockReturnValue(streamSuccess);
-    mockOnUserMediaError = jest.fn().mockReturnValue(streamFailure);
+    mockOnUserMedia = jest.fn();
+    mockOnUserMediaError = jest.fn();
     mockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
 
     props = {

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -1,25 +1,37 @@
+import React from 'react';
 import WebcamFeed from "./WebcamFeed";
-import shallow from "enzyme";
+import { mount } from "enzyme";
+import jsdom from 'jsdom';
+
+const webcamDetected = 'webcam detected';
+const noWebcam = 'no webcam';
+
+
+const mockOnUserMedia = jest.fn(x => webcamDetected);
+const mockOnUserMediaError = jest.fn(() => noWebcam);
 
 const props = {
-  deviceId: 0,
-  onUserMedia: () => { return 'webcam' },
-  onUserMediaError: () => { return 'no webcam' },
+  deviceId: "12345",
+  onUserMedia: mockOnUserMedia,
+  onUserMediaError: mockOnUserMediaError,
 }
 
 describe('Get camera feed', () => {
   it('Should call onUserMediaError when no webcam detected', () => {
-    const wraper = shallow(<WebcamFeed {...props} />)
+    const navigator = new jsdom.JSDOM().window.navigator;
+    mount(<WebcamFeed navigator={navigator} {...props} />);
+    expect(mockOnUserMediaError.mock.results[0].value).toBe(noWebcam);
+  });
+
+  it('Should call onUserMedia when webcam detected', () => {
+    let navigator = new jsdom.JSDOM().window.navigator;
+    Object.defineProperty(navigator, 'mediaDevices', { value: jest.fn(), writable: true});
+    Object.defineProperty(navigator.mediaDevices, 'getUserMedia', { value: jest.fn(x => new Promise((resolver) => { return }))})
+    console.log(navigator.mediaDevices);
+    // navigator.mediaDevices = jest.fn();
+    // navigator.mediaDevices.getUserMedia = jest.fn(x => new Promise((resolve) => { resolve(new MediaStream)}));
+    mount(<WebcamFeed navigator={navigator} {...props} />);
+    console.log(mockOnUserMedia.mock);
+    expect(mockOnUserMedia.mock.results[0].value).toBe(webcamDetected);
   })
 })
-
-
-
-return {
-  "person": {
-    "bbox": [2 2 2 2],
-    "face": {
-      "bbox"
-    }
-  }
-}

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -1,0 +1,25 @@
+import WebcamFeed from "./WebcamFeed";
+import shallow from "enzyme";
+
+const props = {
+  deviceId: 0,
+  onUserMedia: () => { return 'webcam' },
+  onUserMediaError: () => { return 'no webcam' },
+}
+
+describe('Get camera feed', () => {
+  it('Should call onUserMediaError when no webcam detected', () => {
+    const wraper = shallow(<WebcamFeed {...props} />)
+  })
+})
+
+
+
+return {
+  "person": {
+    "bbox": [2 2 2 2],
+    "face": {
+      "bbox"
+    }
+  }
+}

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -1,30 +1,43 @@
 import React from 'react';
-import WebcamFeed from "./WebcamFeed";
+import WebcamFeed, { IWebcamFeedProps } from "./WebcamFeed";
 import { mount, shallow } from "enzyme";
 import jsdom from 'jsdom';
 
+let streamSuccess: string;
+let streamFailure: string;
+let validDeviceId: string;
+
+let mockOnUserMedia: jest.Mock;
+let mockOnUserMediaError: jest.Mock;
+let mockMediaDevices: MediaDevices;
+let props: IWebcamFeedProps;
+
 describe('WebcamFeed', () => {
-  const streamSuccess = 'Stream received';
-  const streamFailure = 'Unable to get stream';
-  const validDeviceId = '123456';
+  beforeEach(() => {
+    streamSuccess = 'Stream received';
+    streamFailure = 'Unable to get stream';
+    validDeviceId = '123456';
 
-  const mockOnUserMedia = jest.fn().mockReturnValue(streamSuccess);
-  const mockOnUserMediaError = jest.fn(() => { return streamFailure });
-  const mockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
+    mockOnUserMedia = jest.fn().mockReturnValue(streamSuccess);
+    mockOnUserMediaError = jest.fn().mockReturnValue(streamFailure);
+    mockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
 
-  const props = {
-    onUserMedia: mockOnUserMedia,
-    onUserMediaError: mockOnUserMediaError,
-    mediaDevices: mockMediaDevices,
-  }
+    props = {
+      onUserMedia: mockOnUserMedia,
+      onUserMediaError: mockOnUserMediaError,
+      mediaDevices: mockMediaDevices,
+      deviceId: validDeviceId,
+    }
+
+  });
 
   it('Should call onUserMediaError when no webcam detected', async () => {
-    mount(<WebcamFeed deviceId={validDeviceId} {...props} />);
+    mount(<WebcamFeed {...props} />);
     expect(mockOnUserMediaError.mock.results[0].value).toBe(streamFailure);
   });
 
   it('Should render video object', () => {
-    const wrapper = shallow(<WebcamFeed deviceId={validDeviceId} {...props} />).debug();
+    const wrapper = shallow(<WebcamFeed {...props} />).debug();
     expect(wrapper).toMatchSnapshot();
   })
 })

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -33,7 +33,7 @@ describe('WebcamFeed', () => {
 
   it('Should call onUserMediaError when no webcam detected', async () => {
     mount(<WebcamFeed {...props} />);
-    expect(mockOnUserMediaError.mock.results[0].value).toBe(streamFailure);
+    expect(mockOnUserMediaError).toHaveBeenCalled();
   });
 
   it('Should render video object', () => {

--- a/src/components/webcamFeed/WebcamFeed.test.tsx
+++ b/src/components/webcamFeed/WebcamFeed.test.tsx
@@ -1,37 +1,40 @@
 import React from 'react';
 import WebcamFeed from "./WebcamFeed";
-import { mount } from "enzyme";
+import { mount, shallow } from "enzyme";
 import jsdom from 'jsdom';
 
-const webcamDetected = 'webcam detected';
-const noWebcam = 'no webcam';
+describe('WebcamFeed', () => {
+  const streamSuccess = 'Stream received';
+  const streamFailure = 'Unable to get stream';
+  const deviceId = '123456';
+
+  const mockOnUserMedia = jest.fn(() => streamSuccess);
+  const mockOnUserMediaError = jest.fn().mockReturnValue(streamFailure);
+  const mockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
+  const myMediaDevices = jest.fn().mockImplementation(() => {
+  });
 
 
-const mockOnUserMedia = jest.fn(x => webcamDetected);
-const mockOnUserMediaError = jest.fn(() => noWebcam);
+  const props = {
+    deviceId: deviceId,
+    onUserMedia: mockOnUserMedia,
+    onUserMediaError: mockOnUserMediaError,
+  }
 
-const props = {
-  deviceId: "12345",
-  onUserMedia: mockOnUserMedia,
-  onUserMediaError: mockOnUserMediaError,
-}
 
-describe('Get camera feed', () => {
   it('Should call onUserMediaError when no webcam detected', () => {
-    const navigator = new jsdom.JSDOM().window.navigator;
-    mount(<WebcamFeed navigator={navigator} {...props} />);
-    expect(mockOnUserMediaError.mock.results[0].value).toBe(noWebcam);
+    mount(<WebcamFeed mediaDevices={mockMediaDevices} {...props} />);
+    expect(mockOnUserMediaError.mock.results[0].value).toBe(streamFailure);
   });
 
   it('Should call onUserMedia when webcam detected', () => {
-    let navigator = new jsdom.JSDOM().window.navigator;
-    Object.defineProperty(navigator, 'mediaDevices', { value: jest.fn(), writable: true});
-    Object.defineProperty(navigator.mediaDevices, 'getUserMedia', { value: jest.fn(x => new Promise((resolver) => { return }))})
-    console.log(navigator.mediaDevices);
-    // navigator.mediaDevices = jest.fn();
-    // navigator.mediaDevices.getUserMedia = jest.fn(x => new Promise((resolve) => { resolve(new MediaStream)}));
-    mount(<WebcamFeed navigator={navigator} {...props} />);
-    console.log(mockOnUserMedia.mock);
-    expect(mockOnUserMedia.mock.results[0].value).toBe(webcamDetected);
+    let myMockMediaDevices = new jsdom.JSDOM().window.navigator.mediaDevices;
+    mount(<WebcamFeed mediaDevices={myMockMediaDevices} {...props} />);
+    expect(mockOnUserMedia.mock.results[0].value).toBe(streamSuccess);
+  })
+
+  it('Should render video object', () => {
+    const wrapper = shallow(<WebcamFeed mediaDevices={mockMediaDevices} {...props} />);
+    expect(wrapper).toMatchSnapshot();
   })
 })

--- a/src/components/webcamFeed/WebcamFeed.tsx
+++ b/src/components/webcamFeed/WebcamFeed.tsx
@@ -4,6 +4,7 @@ interface IWebcamFeedProps {
   deviceId: string,
   onUserMedia: (stream: MediaStream) => void,
   onUserMediaError: () => void,
+  navigator: Navigator,
 }
 
 const WebcamFeed = (props: IWebcamFeedProps) => {
@@ -12,8 +13,10 @@ const WebcamFeed = (props: IWebcamFeedProps) => {
   const [height, setHeight] = useState();
 
   async function getWebcam() {
+    console.log(props.navigator.mediaDevices);
     try {
-      const myStream = await navigator.mediaDevices.getUserMedia({ video: { deviceId: props.deviceId } });
+      const myStream = await props.navigator.mediaDevices.getUserMedia({ video: { deviceId: props.deviceId } });
+      console.log('test');
       if (myStream !== undefined) {
         setStream(myStream);
         var streamSettings = myStream.getVideoTracks()[0].getSettings();

--- a/src/components/webcamFeed/WebcamFeed.tsx
+++ b/src/components/webcamFeed/WebcamFeed.tsx
@@ -27,7 +27,7 @@ const WebcamFeed = (props: IWebcamFeedProps) => {
           }
           props.onUserMedia(myStream);
         }
-      } catch {
+      } catch (error) {
         props.onUserMediaError();
       }
     }

--- a/src/components/webcamFeed/WebcamFeed.tsx
+++ b/src/components/webcamFeed/WebcamFeed.tsx
@@ -4,8 +4,10 @@ interface IWebcamFeedProps {
   deviceId: string,
   onUserMedia: (stream: MediaStream) => void,
   onUserMediaError: () => void,
-  navigator: Navigator,
+  mediaDevices: MediaDevices ,
 }
+
+
 
 const WebcamFeed = (props: IWebcamFeedProps) => {
   const [stream, setStream] = useState();
@@ -13,21 +15,21 @@ const WebcamFeed = (props: IWebcamFeedProps) => {
   const [height, setHeight] = useState();
 
   async function getWebcam() {
-    console.log(props.navigator.mediaDevices);
-    try {
-      const myStream = await props.navigator.mediaDevices.getUserMedia({ video: { deviceId: props.deviceId } });
-      console.log('test');
-      if (myStream !== undefined) {
-        setStream(myStream);
-        var streamSettings = myStream.getVideoTracks()[0].getSettings();
-        if (streamSettings.height && streamSettings.width) {
-          setHeight(streamSettings.height);
-          setWidth(streamSettings.width);
+    if (stream === undefined) {
+      try {
+        const myStream = await props.mediaDevices.getUserMedia({ video: { deviceId: props.deviceId } });
+        if (myStream !== undefined) {
+          setStream(myStream);
+          var streamSettings = myStream.getVideoTracks()[0].getSettings();
+          if (streamSettings.height && streamSettings.width) {
+            setHeight(streamSettings.height);
+            setWidth(streamSettings.width);
+          }
+          props.onUserMedia(myStream);
         }
-        props.onUserMedia(myStream);
+      } catch {
+        props.onUserMediaError();
       }
-    } catch {
-      props.onUserMediaError();
     }
   };
 

--- a/src/components/webcamFeed/__snapshots__/WebcamFeed.test.tsx.snap
+++ b/src/components/webcamFeed/__snapshots__/WebcamFeed.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WebcamFeed Should render video object 1`] = `ShallowWrapper {}`;

--- a/src/components/webcamFeed/__snapshots__/WebcamFeed.test.tsx.snap
+++ b/src/components/webcamFeed/__snapshots__/WebcamFeed.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WebcamFeed Should render video object 1`] = `ShallowWrapper {}`;
+exports[`WebcamFeed Should render video object 1`] = `"<video className=\\"123456 hidden\\" autoPlay={true} height={[undefined]} width={[undefined]} src={[undefined]} />"`;

--- a/src/setupEnzyme.js
+++ b/src/setupEnzyme.js
@@ -1,4 +1,0 @@
-import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-Enzyme.configure({ adapter: new Adapter() });

--- a/src/setupEnzyme.js
+++ b/src/setupEnzyme.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });


### PR DESCRIPTION
Created two tests for WebcamFeed component: 
- onUserMediaError should be called if no webcam is detected
- Snapshot test
and updated webcamFeed to take a MediaDevices object as a parameter instead of calling it directly from the navigator.
Unable to test the onUserMedia callback, since currently there doesn't seem to be a way of mocking MediaDevices object. 