### PR TITLE
Refactor/131 export create store not store

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Store } from 'redux';
 import './App.css';
 import ConfigMenuElement from './components/configMenu/ConfigMenuElement';
 import DetectionHandler from './components/detectionHandler/DetectionHandler';
@@ -8,6 +7,7 @@ import EyeController from './components/eye/EyeController';
 import Video from './components/video/Video';
 import { IRootStore } from './store/reducers/rootReducer';
 import { getDeviceIds } from './store/selectors/videoSelectors';
+import { AppStore } from './store/store';
 
 interface IAppState {
     width: number;
@@ -21,9 +21,9 @@ interface IAppProps {
         mediaDevices: MediaDevices,
         onUserMedia: () => void,
         onUserMediaError: () => void,
-        store: Store<IRootStore>,
+        store: AppStore,
     ) => void;
-    store: Store<IRootStore>;
+    store: AppStore;
 }
 
 interface IAppMapStateToProps {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { Store } from 'redux';
 import './App.css';
 import ConfigMenuElement from './components/configMenu/ConfigMenuElement';
 import DetectionHandler from './components/detectionHandler/DetectionHandler';
@@ -20,7 +21,9 @@ interface IAppProps {
         mediaDevices: MediaDevices,
         onUserMedia: () => void,
         onUserMediaError: () => void,
+        store: Store<IRootStore>,
     ) => void;
+    store: Store<IRootStore>;
 }
 
 interface IAppMapStateToProps {
@@ -61,6 +64,7 @@ export class App extends React.PureComponent<AppProps, IAppState> {
             this.props.environment.navigator.mediaDevices,
             this.onUserMedia,
             this.onUserMediaError,
+            this.props.store,
         );
     }
 

--- a/src/components/configMenu/ConfigMenuElement.tsx
+++ b/src/components/configMenu/ConfigMenuElement.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
-<<<<<<< HEAD
-=======
-import { configStorageKey } from '../../AppConstants';
->>>>>>> removed direct store.dispatch() calls
 import {
     ISetConfigPayload,
     UPDATE_CONFIG,

--- a/src/components/configMenu/ConfigMenuElement.tsx
+++ b/src/components/configMenu/ConfigMenuElement.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
+<<<<<<< HEAD
+=======
+import { configStorageKey } from '../../AppConstants';
+>>>>>>> removed direct store.dispatch() calls
 import {
     ISetConfigPayload,
     UPDATE_CONFIG,

--- a/src/components/webcamHandler/WebcamHandler.ts
+++ b/src/components/webcamHandler/WebcamHandler.ts
@@ -1,6 +1,7 @@
 import { Store } from 'redux';
 import { SET_VIDEO_STREAMS } from '../../store/actions/video/types';
 import { IRootStore } from '../../store/reducers/rootReducer';
+import { AppStore } from '../../store/store';
 
 const videoinput = 'videoinput';
 
@@ -8,7 +9,7 @@ export default async function configureStream(
     mediaDevices: MediaDevices,
     onUserMedia: () => void,
     onUserMediaError: () => void,
-    store: Store<IRootStore>,
+    store: AppStore,
 ) {
     try {
         const devices = await enumerateDevices(mediaDevices);

--- a/src/components/webcamHandler/WebcamHandler.ts
+++ b/src/components/webcamHandler/WebcamHandler.ts
@@ -1,5 +1,6 @@
+import { Store } from 'redux';
 import { SET_VIDEO_STREAMS } from '../../store/actions/video/types';
-import store from '../../store/store';
+import { IRootStore } from '../../store/reducers/rootReducer';
 
 const videoinput = 'videoinput';
 
@@ -7,6 +8,7 @@ export default async function configureStream(
     mediaDevices: MediaDevices,
     onUserMedia: () => void,
     onUserMediaError: () => void,
+    store: Store<IRootStore>,
 ) {
     try {
         const devices = await enumerateDevices(mediaDevices);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,11 +5,13 @@ import App from './App';
 import configureStream from './components/webcamHandler/WebcamHandler';
 import './index.css';
 import * as serviceWorker from './serviceWorker';
-import store from './store/store';
+import { createStore } from './store/store';
 
 const getEnvironment = () => {
     return window;
 };
+
+const store = createStore();
 
 ReactDOM.render(
     <Provider store={store}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,11 @@ const store = createStore();
 
 ReactDOM.render(
     <Provider store={store}>
-        <App environment={getEnvironment()} configureStream={configureStream} />
+        <App
+            environment={getEnvironment()}
+            configureStream={configureStream}
+            store={store}
+        />
     </Provider>,
     document.getElementById('root'),
 );

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -7,7 +7,7 @@ import { load, save } from 'redux-localstorage-simple';
 import reducer from './reducers/rootReducer';
 
 const states = ['configStore'];
-const middleware: Middleware[] = [];
+const middleware: Middleware[] = [save({ states })];
 
 export function createStore() {
     return createReduxStore(

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,12 +1,18 @@
-import { applyMiddleware, createStore } from 'redux';
+import {
+    applyMiddleware,
+    createStore as createReduxStore,
+    Middleware,
+} from 'redux';
 import { load, save } from 'redux-localstorage-simple';
 import reducer from './reducers/rootReducer';
 
 const states = ['configStore'];
-const store = createStore(
-    reducer,
-    load({ states }),
-    applyMiddleware(save({ states })),
-);
+const middleware: Middleware[] = [];
 
-export default store;
+export function createStore() {
+    return createReduxStore(
+        reducer,
+        load({ states }),
+        applyMiddleware(...middleware),
+    );
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,9 +2,10 @@ import {
     applyMiddleware,
     createStore as createReduxStore,
     Middleware,
+    Store,
 } from 'redux';
 import { load, save } from 'redux-localstorage-simple';
-import reducer from './reducers/rootReducer';
+import reducer, { IRootStore } from './reducers/rootReducer';
 
 const states = ['configStore'];
 const middleware: Middleware[] = [save({ states })];
@@ -16,3 +17,5 @@ export function createStore() {
         applyMiddleware(...middleware),
     );
 }
+
+export type AppStore = Store<IRootStore>;


### PR DESCRIPTION
This pull request resolves issue #131 regarding using an imported instance of the store. The store is now passed to the application via a provider. 

This PR has spawned issue #151 to refactor the webcam handler as a thunk. This will eliminate passing an instance of the store to it and calling store.dispatch from the webcam handler.