### PR TITLE
Added test coverage for CocoSSD

### DIFF
--- a/src/__tests__/utils/cocoSSD.test.ts
+++ b/src/__tests__/utils/cocoSSD.test.ts
@@ -1,0 +1,38 @@
+import * as ssd from '@tensorflow-models/coco-ssd';
+import { IDetection, IObjectDetector } from '../../models/objectDetection';
+import CocoSSD from '../../utils/objectDetection/cocoSSD';
+import { Bbox } from '../../utils/types';
+
+const testBbox: Bbox = [1, 2, 3, 4];
+const testType: string = 'person';
+const testScore: number = 50;
+
+const testInput: ssd.DetectedObject[] = [
+    {
+        bbox: testBbox,
+        class: testType,
+        score: testScore,
+    },
+];
+
+const testOutput: IDetection[] = [
+    {
+        bbox: testBbox,
+        info: { type: testType, certainty: testScore },
+    },
+];
+
+describe('CocoSSD', () => {
+    let testCoco: IObjectDetector;
+    beforeAll(async () => {
+        testCoco = await CocoSSD.init();
+    }, 60000);
+
+    it('model should load successfully', () => {
+        expect(testCoco).toBeInstanceOf(CocoSSD);
+    });
+
+    it('shapeDetect should return object of shape IDetection', () => {
+        expect(testCoco.reshapeDetections(testInput)).toStrictEqual(testOutput);
+    });
+});

--- a/src/models/objectDetection.ts
+++ b/src/models/objectDetection.ts
@@ -2,6 +2,7 @@ import * as ssd from '@tensorflow-models/coco-ssd';
 import { Bbox, DetectionImage } from '../utils/types';
 
 export interface IObjectDetector {
+    reshapeDetections(testInput: ssd.DetectedObject[]): IDetection[];
     detect(
         image: DetectionImage,
         detectionConfig?: DetectionConfig,

--- a/src/utils/objectDetection/cocoSSD.ts
+++ b/src/utils/objectDetection/cocoSSD.ts
@@ -17,6 +17,10 @@ export default class CocoSSD implements IObjectDetector {
         maxDetections: number = 5,
     ): Promise<IDetection[]> {
         const detections = await this.model.detect(image, maxDetections);
+        return this.reshapeDetections(detections);
+    }
+
+    reshapeDetections(detections: ssd.DetectedObject[]): IDetection[] {
         return detections.map(detection => {
             return {
                 bbox: detection.bbox,


### PR DESCRIPTION
Just a small commit to patch the untested CocoSSD class. 

Test coverage now covers most of the class, except for lines 19/20 that should be covered by tensorflow.