### PR TITLE
fixed bug in calculateTargetPos

### DIFF
--- a/src/__tests__/utils/calculateFocus.test.ts
+++ b/src/__tests__/utils/calculateFocus.test.ts
@@ -39,8 +39,8 @@ describe('normalise should return', () => {
 
 describe('calculateTargetPos should return', () => {
     const testValues: Array<[Bbox, ICoords]> = [
-        [[0, 0, 10, 20], { x: 5, y: 15 }],
-        [[50, 800, 100, 200], { x: 100, y: 950 }],
+        [[0, 0, 10, 20], { x: 5, y: 5 }],
+        [[50, 800, 100, 200], { x: 100, y: 850 }],
         [[42, 21, 0, 0], { x: 42, y: 21 }],
     ];
     it.each(testValues)(

--- a/src/utils/objectTracking/calculateFocus.ts
+++ b/src/utils/objectTracking/calculateFocus.ts
@@ -2,7 +2,7 @@ import { Bbox, ICoords } from '../types';
 
 export default function calculateTargetPos(bbox: Bbox): ICoords {
     const [x, y, width, height] = bbox;
-    return { x: x + width / 2, y: y + (height * 3) / 4 };
+    return { x: x + width / 2, y: y + height / 4 };
 }
 
 export function normalise(


### PR DESCRIPTION
the previous version of this function was written while considering the y axis increasing in value from bottom to top, whereas it _should_ increase in value from top to bottom.