### PR TITLE
feature/223-add-model-config-dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ When mouse movement is detected on the screen, the configuration menu will open 
 
 | Option        | Description                                                                  |
 | ------------- | ---------------------------------------------------------------------------- |
+| Model         | Sets the model to be used for detection. This affects performance            |
+| FPS           | Sets the FPS for the object detection                                        |
 | X Sensitivity | X axis eyes sensitivity                                                      |
 | Y Sensitivity | Y axis eyes sensitivity                                                      |
+| Iris Colour   | Changes the colour of the Iris                                               |
 | Swap Eyes     | Available when two webcams are detected. Swaps the webcam input for the eyes |
 | Toggle Debug  | Displays the camera feed with bounding boxes                                 |
-| Iris Colour   | Changes the colour of the Iris                                               |
 
 ## Testing
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,8 +52,7 @@ const mapDispatchToProps = (
     dispatch: ThunkDispatch<IRootStore, void, Action>,
 ) => {
     return {
-        loadModel: (init: () => Promise<IObjectDetector>) =>
-            dispatch(loadModel(init)),
+        loadModel: () => dispatch(loadModel()),
     };
 };
 

--- a/src/__tests__/components/ConfigMenu.test.tsx
+++ b/src/__tests__/components/ConfigMenu.test.tsx
@@ -51,15 +51,15 @@ describe('ConfigMenu', () => {
         expect(map).toHaveProperty('mousemove');
     });
 
-    it('should call onMouseMove', () => {
+    it('should call mouseMoveHandler', () => {
         const wrapper = mount(<ConfigMenu {...props} />);
         wrapper.simulate('mousemove');
-        expect(wrapper.state('isUnderMouse')).toBe(true);
+        expect(wrapper.state('isUnderMouse')).toBe(false);
     });
 
     it('should call onMouseLeave', () => {
         const wrapper = mount(<ConfigMenu {...props} />);
-        wrapper.simulate('mousemove');
+        wrapper.simulate('mouseenter');
         expect(wrapper.state('isUnderMouse')).toBe(true);
         wrapper.simulate('mouseleave');
         expect(wrapper.state('isUnderMouse')).toBe(false);

--- a/src/__tests__/components/ConfigMenuElement.test.tsx
+++ b/src/__tests__/components/ConfigMenuElement.test.tsx
@@ -6,6 +6,7 @@ import {
     ConfigMenuElementProps,
 } from '../../components/configMenu/ConfigMenuElement';
 import IUserConfig from '../../components/configMenu/IUserConfig';
+import { DetectionModelType } from '../../models/objectDetection';
 
 let props: ConfigMenuElementProps;
 let config: IUserConfig;
@@ -14,6 +15,7 @@ let window: Window;
 describe('ConfigMenuElement tests', () => {
     beforeEach(() => {
         config = {
+            model: DetectionModelType.Posenet,
             xSensitivity: 1,
             ySensitivity: 1,
             fps: 30,

--- a/src/__tests__/components/__snapshots__/ConfigMenu.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/ConfigMenu.test.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfigMenu should render correctly 1`] = `
-"<div style={{...}} className=\\"ConfigMenu\\" onMouseMove={[Function: bound onMouseMove]} onMouseLeave={[Function: bound onMouseLeave]}>
+"<div style={{...}} className=\\"ConfigMenu\\" onMouseEnter={[Function: bound onMouseEnter]} onMouseLeave={[Function: bound onMouseLeave]}>
   <h1>
     Config
   </h1>
-  <Memo() name=\\"textBox\\" configName=\\"textBox\\" defaultValue={20} onValidInput={[Function: mockConstructor]} configParse={[Function: mockConstructor]} helpWith={0} step={1} />
+  <Memo() name=\\"textBox\\" configName=\\"textBox\\" defaultValue={20} onValidInput={[Function: mockConstructor]} configParse={[Function: mockConstructor]} helpWith=\\"FPS\\" step={1} />
 </div>"
 `;

--- a/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
@@ -2,24 +2,32 @@
 
 exports[`ConfigMenuElement tests should render correctly 1`] = `
 "<ConfigMenu width=\\"14em\\" timerLength={1000} window={{...}} debugEnabled={false}>
-  <Memo() name=\\"X Sensitivity\\" configName=\\"xSensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith={1} />
-  <Memo() name=\\"Y Sensitivity\\" configName=\\"ySensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith={2} />
-  <Memo() name=\\"FPS\\" configName=\\"fps\\" step={1} defaultValue={30} onValidInput={[Function: mockConstructor]} configParse={[Function: parseInt]} helpWith={0} />
-  <Memo() name=\\"Swap Eyes\\" configName=\\"swapEyes\\" helpWith={6} checked={false} onInputChange={[Function: mockConstructor]} />
-  <Memo() name=\\"Iris Colour\\" configName=\\"irisColor\\" color=\\"blue\\" onInputChange={[Function: mockConstructor]} helpWith={7} />
-  <Memo() name=\\"Toggle Debug\\" configName=\\"toggleDebug\\" helpWith={9} checked={false} onInputChange={[Function: mockConstructor]} />
+  <span data-tip={true} data-for=\\"APP\\">
+    ?
+  </span>
+  <Memo() name=\\"Model\\" configName=\\"model\\" onInputChange={[Function: mockConstructor]} values={{...}} defaultValue=\\"posenet\\" helpWith=\\"MODEL\\" />
+  <Memo() name=\\"FPS\\" configName=\\"fps\\" step={1} defaultValue={30} onValidInput={[Function: mockConstructor]} configParse={[Function: parseInt]} helpWith=\\"FPS\\" />
+  <br />
+  <Memo() name=\\"X Sensitivity\\" configName=\\"xSensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"X_SENSITIVITY\\" />
+  <Memo() name=\\"Y Sensitivity\\" configName=\\"ySensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"Y_SENSITIVITY\\" />
+  <Memo() name=\\"Iris Colour\\" configName=\\"irisColor\\" color=\\"blue\\" onInputChange={[Function: mockConstructor]} helpWith=\\"IRIS_COLOUR\\" />
+  <br />
+  <Memo() name=\\"Swap Eyes\\" configName=\\"swapEyes\\" helpWith=\\"SWAP_EYES\\" checked={false} onInputChange={[Function: mockConstructor]} />
+  <Memo() name=\\"Toggle Debug\\" configName=\\"toggleDebug\\" helpWith=\\"DEBUG\\" checked={false} onInputChange={[Function: mockConstructor]} />
   <br />
   <p data-tip={true} data-for=\\"APP\\">
     Help
   </p>
-  <Help problemWith={0} />
-  <Help problemWith={1} />
-  <Help problemWith={2} />
-  <Help problemWith={6} />
-  <Help problemWith={7} />
-  <Help problemWith={8} />
-  <Help problemWith={9} />
-  <Help problemWith={4} />
-  <Help problemWith={5} />
+  <Help problemWith=\\"MODEL\\" />
+  <Help problemWith=\\"FPS\\" />
+  <Help problemWith=\\"X_SENSITIVITY\\" />
+  <Help problemWith=\\"Y_SENSITIVITY\\" />
+  <Help problemWith=\\"VIDEO_STREAM\\" />
+  <Help problemWith=\\"LEFT_VIDEO_STREAM\\" />
+  <Help problemWith=\\"RIGHT_VIDEO_STREAM\\" />
+  <Help problemWith=\\"SWAP_EYES\\" />
+  <Help problemWith=\\"IRIS_COLOUR\\" />
+  <Help problemWith=\\"APP\\" />
+  <Help problemWith=\\"DEBUG\\" />
 </ConfigMenu>"
 `;

--- a/src/__tests__/reducers/config/configReducer.test.ts
+++ b/src/__tests__/reducers/config/configReducer.test.ts
@@ -1,6 +1,7 @@
+import { DetectionModelType } from '../../../models/objectDetection';
 import {
     resetConfigAction,
-    updateConfigAction,
+    setConfigAction,
 } from '../../../store/actions/config/actions';
 import { IConfigState } from '../../../store/actions/config/types';
 import configStore, {
@@ -10,6 +11,7 @@ import configStore, {
 describe('Config Reducer tests', () => {
     const testState: IConfigState = {
         config: {
+            model: DetectionModelType.Posenet,
             xSensitivity: 10,
             ySensitivity: 10,
             fps: 5,
@@ -24,9 +26,10 @@ describe('Config Reducer tests', () => {
     });
     it('update config with partial state, so some values are updated and others are as they were before', () => {
         const partialConfig = { fps: 555, toggleDebug: true, irisColor: 'red' };
-        const updateAction = updateConfigAction({ partialConfig });
+        const setAction = setConfigAction({ partialConfig });
         const alteredState: IConfigState = {
             config: {
+                model: DetectionModelType.Posenet,
                 xSensitivity: 10,
                 ySensitivity: 10,
                 fps: 555,
@@ -35,8 +38,6 @@ describe('Config Reducer tests', () => {
                 toggleDebug: true,
             },
         };
-        expect(configStore(testState, updateAction)).toStrictEqual(
-            alteredState,
-        );
+        expect(configStore(testState, setAction)).toStrictEqual(alteredState);
     });
 });

--- a/src/components/configMenu/ConfigMenu.css
+++ b/src/components/configMenu/ConfigMenu.css
@@ -34,16 +34,21 @@
 .ConfigMenu a,
 .ConfigMenu label,
 .ConfigMenu input,
+.ConfigMenu select,
 .ConfigMenu h1 {
     padding: 10px;
-    width: 50%;
+    width: calc(var(--canvas-width) / 2);
     display: inline-block;
 }
 
 .ConfigMenu input {
-    width: 25%;
+    width: calc(var(--canvas-width) / 4);
+}
+
+.ConfigMenu select {
+    width: calc(var(--canvas-width) / 2.9);
 }
 
 .ConfigMenu #canvas {
-    width: 100%;
+    width: var(--canvas-width);
 }

--- a/src/components/configMenu/ConfigMenu.tsx
+++ b/src/components/configMenu/ConfigMenu.tsx
@@ -22,7 +22,7 @@ export default class ConfigMenu extends React.Component<
     constructor(props: IConfigMenuProps) {
         super(props);
         this.state = { leftPosition: '0px', isUnderMouse: false };
-        this.onMouseMove = this.onMouseMove.bind(this);
+        this.onMouseEnter = this.onMouseEnter.bind(this);
         this.onMouseLeave = this.onMouseLeave.bind(this);
         this.mouseMoveHandler = this.mouseMoveHandler.bind(this);
         this.props.window.addEventListener('mousemove', this.mouseMoveHandler);
@@ -39,7 +39,7 @@ export default class ConfigMenu extends React.Component<
         }
     }
 
-    onMouseMove() {
+    onMouseEnter() {
         clearInterval(this.hideTimeout);
         this.setState({ isUnderMouse: true });
     }
@@ -65,7 +65,7 @@ export default class ConfigMenu extends React.Component<
                     left: this.state.leftPosition,
                 }}
                 className={'ConfigMenu'}
-                onMouseMove={this.onMouseMove}
+                onMouseEnter={this.onMouseEnter}
                 onMouseLeave={this.onMouseLeave}
             >
                 <h1>Config</h1>

--- a/src/components/configMenu/ConfigMenuElement.tsx
+++ b/src/components/configMenu/ConfigMenuElement.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import isEqual from 'react-fast-compare';
 import { connect } from 'react-redux';
-import { Dispatch } from 'redux';
-import {
-    ISetConfigPayload,
-    UPDATE_CONFIG,
-} from '../../store/actions/config/types';
+import { Action } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { DetectionModelType } from '../../models/objectDetection';
+import { updateConfigAction } from '../../store/actions/config/actions';
+import { ISetConfigPayload } from '../../store/actions/config/types';
 import { IRootStore } from '../../store/reducers/rootReducer';
 import { getConfig } from '../../store/selectors/configSelectors';
 import { getVideos } from '../../store/selectors/videoSelectors';
@@ -15,6 +15,7 @@ import IUserConfig from './IUserConfig';
 import CanvasMenuItem from './menuItems/CanvasMenuItem';
 import CheckBoxMenuItem from './menuItems/CheckBoxMenuItem';
 import ColorMenuItem from './menuItems/ColorMenuItem';
+import DropDownMenuItem from './menuItems/DropDownMenuItem';
 import TextBoxMenuItem from './menuItems/TextBoxMenuItem';
 
 export interface IConfigMenuElementProps {
@@ -38,11 +39,12 @@ const mapStateToProps = (
 interface IConfigMenuElementMapDispatchToProps {
     setConfig: (payload: ISetConfigPayload) => void;
 }
-
-const mapDispatchToProps = (dispatch: Dispatch) => {
+const mapDispatchToProps = (
+    dispatch: ThunkDispatch<IRootStore, void, Action>,
+) => {
     return {
         setConfig: (payload: ISetConfigPayload) =>
-            dispatch({ type: UPDATE_CONFIG, payload }),
+            dispatch(updateConfigAction(payload)),
     };
 };
 
@@ -64,6 +66,31 @@ export const ConfigMenuElement = React.memo(
                 window={props.window}
                 debugEnabled={props.config.toggleDebug}
             >
+                <span data-tip={true} data-for={HelpWith[HelpWith.APP]}>
+                    ?
+                </span>
+
+                <DropDownMenuItem
+                    name={'Model'}
+                    configName={'model'}
+                    onInputChange={props.setConfig}
+                    values={Object.values(DetectionModelType)}
+                    defaultValue={props.config.model}
+                    helpWith={HelpWith.MODEL}
+                />
+
+                <TextBoxMenuItem
+                    name={'FPS'}
+                    configName={'fps'}
+                    step={1}
+                    defaultValue={props.config.fps}
+                    onValidInput={props.setConfig}
+                    configParse={parseInt}
+                    helpWith={HelpWith.FPS}
+                />
+
+                <br />
+
                 <TextBoxMenuItem
                     name={'X Sensitivity'}
                     configName={'xSensitivity'}
@@ -82,28 +109,23 @@ export const ConfigMenuElement = React.memo(
                     configParse={parseFloat}
                     helpWith={HelpWith.Y_SENSITIVITY}
                 />
-                <TextBoxMenuItem
-                    name={'FPS'}
-                    configName={'fps'}
-                    step={1}
-                    defaultValue={props.config.fps}
-                    onValidInput={props.setConfig}
-                    configParse={parseInt}
-                    helpWith={HelpWith.FPS}
-                />
-                <CheckBoxMenuItem
-                    name={'Swap Eyes'}
-                    configName={'swapEyes'}
-                    helpWith={HelpWith.SWAP_EYES}
-                    checked={props.config.swapEyes}
-                    onInputChange={props.setConfig}
-                />
+
                 <ColorMenuItem
                     name={'Iris Colour'}
                     configName={'irisColor'}
                     color={props.config.irisColor}
                     onInputChange={props.setConfig}
                     helpWith={HelpWith.IRIS_COLOUR}
+                />
+
+                <br />
+
+                <CheckBoxMenuItem
+                    name={'Swap Eyes'}
+                    configName={'swapEyes'}
+                    helpWith={HelpWith.SWAP_EYES}
+                    checked={props.config.swapEyes}
+                    onInputChange={props.setConfig}
                 />
                 <CheckBoxMenuItem
                     name={'Toggle Debug'}
@@ -133,15 +155,10 @@ export const ConfigMenuElement = React.memo(
                 <p data-tip={true} data-for={HelpWith[HelpWith.APP]}>
                     Help
                 </p>
-                <Help problemWith={HelpWith.FPS} />
-                <Help problemWith={HelpWith.X_SENSITIVITY} />
-                <Help problemWith={HelpWith.Y_SENSITIVITY} />
-                <Help problemWith={HelpWith.SWAP_EYES} />
-                <Help problemWith={HelpWith.IRIS_COLOUR} />
-                <Help problemWith={HelpWith.APP} />
-                <Help problemWith={HelpWith.DEBUG} />
-                <Help problemWith={HelpWith.LEFT_VIDEO_STREAM} />
-                <Help problemWith={HelpWith.RIGHT_VIDEO_STREAM} />
+
+                {Object.values(HelpWith).map((type, key: number) => (
+                    <Help key={key} problemWith={HelpWith[type] as HelpWith} />
+                ))}
             </ConfigMenu>
         );
     },

--- a/src/components/configMenu/Help.tsx
+++ b/src/components/configMenu/Help.tsx
@@ -2,17 +2,28 @@ import React, { Fragment } from 'react';
 import ReactTooltip from 'react-tooltip';
 
 export enum HelpWith {
-    FPS,
-    X_SENSITIVITY,
-    Y_SENSITIVITY,
-    VIDEO_STREAM,
-    LEFT_VIDEO_STREAM,
-    RIGHT_VIDEO_STREAM,
-    SWAP_EYES,
-    IRIS_COLOUR,
-    APP,
-    DEBUG,
+    MODEL = 'MODEL',
+    FPS = 'FPS',
+    X_SENSITIVITY = 'X_SENSITIVITY',
+    Y_SENSITIVITY = 'Y_SENSITIVITY',
+    VIDEO_STREAM = 'VIDEO_STREAM',
+    LEFT_VIDEO_STREAM = 'LEFT_VIDEO_STREAM',
+    RIGHT_VIDEO_STREAM = 'RIGHT_VIDEO_STREAM',
+    SWAP_EYES = 'SWAP_EYES',
+    IRIS_COLOUR = 'IRIS_COLOUR',
+    APP = 'APP',
+    DEBUG = 'DEBUG',
 }
+
+const model = () => {
+    return (
+        <Fragment>
+            This sets the model running in the background. Posenet runs faster
+            and is more accurate.
+            <br /> CocoSSD is supported for legacy reasons.
+        </Fragment>
+    );
+};
 
 const fps = () => {
     return (
@@ -109,6 +120,7 @@ interface IHelpSectionMap {
 }
 
 const helpSections: IHelpSectionMap = {
+    MODEL: model,
     FPS: fps,
     X_SENSITIVITY: xSense,
     Y_SENSITIVITY: ySense,

--- a/src/components/configMenu/IUserConfig.tsx
+++ b/src/components/configMenu/IUserConfig.tsx
@@ -1,4 +1,7 @@
+import { DetectionModelType } from '../../models/objectDetection';
+
 export default interface IUserConfig {
+    model: DetectionModelType;
     xSensitivity: number;
     ySensitivity: number;
     fps: number;

--- a/src/components/configMenu/menuItems/CanvasMenuItem.tsx
+++ b/src/components/configMenu/menuItems/CanvasMenuItem.tsx
@@ -62,7 +62,6 @@ export class CanvasMenuItem extends React.Component<CanvasMenuItemProps> {
     ) {
         return (
             previousProps.selections !== nextProps.selections ||
-            previousProps.name !== nextProps.name ||
             previousProps.videoIndex !== nextProps.videoIndex
         );
     }

--- a/src/components/configMenu/menuItems/CheckBoxMenuItem.tsx
+++ b/src/components/configMenu/menuItems/CheckBoxMenuItem.tsx
@@ -28,7 +28,6 @@ const CheckBoxMenuItem = React.memo(
             </div>
         );
     },
-    (previous, next) =>
-        previous.checked === next.checked && previous.name === next.name,
+    (previous, next) => previous.checked === next.checked,
 );
 export default CheckBoxMenuItem;

--- a/src/components/configMenu/menuItems/ColorMenuItem.tsx
+++ b/src/components/configMenu/menuItems/ColorMenuItem.tsx
@@ -24,7 +24,6 @@ const ColorMenuItem = React.memo(
             </div>
         );
     },
-    (previous, next) =>
-        previous.color === next.color && previous.name === next.name,
+    (previous, next) => previous.color === next.color,
 );
 export default ColorMenuItem;

--- a/src/components/configMenu/menuItems/DropDownMenuItem.tsx
+++ b/src/components/configMenu/menuItems/DropDownMenuItem.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ISetConfigPayload } from '../../../store/actions/config/types';
+import { HelpWith } from '../Help';
+
+export interface IDropDownMenuItemProps {
+    name: string;
+    configName: string;
+    onInputChange: (payload: ISetConfigPayload) => void;
+    values: string[];
+    defaultValue: string;
+    helpWith: HelpWith;
+}
+
+const DropDownMenuItem = React.memo(
+    (props: IDropDownMenuItemProps) => {
+        function onChange(event: React.ChangeEvent<HTMLSelectElement>) {
+            props.onInputChange({
+                partialConfig: { [props.configName]: event.target.value },
+            });
+        }
+
+        return (
+            <div data-tip={true} data-for={HelpWith[props.helpWith]}>
+                <label>{props.name}</label>
+                <select onChange={onChange} value={props.defaultValue}>
+                    {props.values.map((value, index) => (
+                        <option value={value} key={index}>
+                            {value}
+                        </option>
+                    ))}
+                </select>
+            </div>
+        );
+    },
+    (previous, next) => previous.defaultValue === next.defaultValue,
+);
+
+export default DropDownMenuItem;

--- a/src/models/objectDetection.ts
+++ b/src/models/objectDetection.ts
@@ -11,8 +11,8 @@ export type DetectedObject = ssdObject | Pose;
 export type Detection = ICocoSSDDetection | IPosenetDetection;
 
 export enum DetectionModelType {
-    CocoSSD = 'CocoSSD',
-    Posenet = 'Posenet',
+    Posenet = 'posenet',
+    CocoSSD = 'cocossd',
 }
 
 export interface IDetection {

--- a/src/store/actions/config/actions.ts
+++ b/src/store/actions/config/actions.ts
@@ -1,17 +1,30 @@
+import { Action } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { IRootStore } from '../../reducers/rootReducer';
+import { loadModel } from '../detections/actions';
 import {
     ConfigActionTypes,
     ISetConfigPayload,
     RESET_CONFIG,
     UPDATE_CONFIG,
 } from './types';
-export function updateConfigAction(
-    payload: ISetConfigPayload,
-): ConfigActionTypes {
+
+export function updateConfigAction(payload: ISetConfigPayload) {
+    return (dispatch: ThunkDispatch<IRootStore, void, Action>) => {
+        dispatch(setConfigAction(payload));
+        if (payload.partialConfig.model) {
+            dispatch(loadModel());
+        }
+    };
+}
+
+export function setConfigAction(payload: ISetConfigPayload): ConfigActionTypes {
     return {
         type: UPDATE_CONFIG,
         payload,
     };
 }
+
 export function resetConfigAction(): ConfigActionTypes {
     return {
         type: RESET_CONFIG,

--- a/src/store/actions/detections/types.ts
+++ b/src/store/actions/detections/types.ts
@@ -18,7 +18,7 @@ export interface IDetectionState {
 
 export interface ISetModelAction {
     type: 'SET_MODEL';
-    payload: IObjectDetector;
+    payload: IObjectDetector | null;
 }
 
 export interface ISetIntervalAction {

--- a/src/store/reducers/configReducer.ts
+++ b/src/store/reducers/configReducer.ts
@@ -1,3 +1,4 @@
+import { DetectionModelType } from '../../models/objectDetection';
 import {
     ConfigActionTypes,
     IConfigState,
@@ -7,12 +8,13 @@ import {
 
 export const initialState: IConfigState = {
     config: {
+        model: DetectionModelType.Posenet,
         xSensitivity: 1,
         ySensitivity: 1,
         fps: 2,
         swapEyes: false,
         toggleDebug: false,
-        irisColor: '#55acee', // must be hex value, as this is passed to colour picker input,
+        irisColor: '#55acee', // must be hex value, as this is passed to colour picker input
     },
 };
 


### PR DESCRIPTION
This PR addresses #223 regarding adding a dropdown option for the models. 

To add this a drop down menu item component was created.
The updateConfig action was changed to be a thunk which has sideeffects for specific updates. This will be useful for #218 regarding updating the fps live.
Additionally, some refactoring was done which changed the rendering of the help tips to be easier to maintain alongside a minor improvement to the usage of mouse events to trigger less often. 

The commits for this PR were squashed locally with the following commits:

- changed onMouseMove to onMouseEnter event
- added drop down menu for models and updated readme
- added thunk for sideeffects from updating config menu
- integrated loadModel with updateConfig thunk
- refactored help rendering and added loading between model swaps
- fixed tests to reflect changes
- fixed minor discrepancies