### PR TITLE
feature/218-update-fps-without-reload

### DIFF
--- a/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
@@ -1,17 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfigMenuElement tests should render correctly 1`] = `
-<<<<<<< HEAD
 "<ConfigMenu width=\\"14em\\" timerLength={1000} window={{...}} debugEnabled={false}>
-=======
-"<ConfigMenu width=\\"14em\\" timerLength={1000} window={{...}}>
->>>>>>> Added dropdown menu for model to config menu
   <span data-tip={true} data-for=\\"APP\\">
     ?
   </span>
   <Memo() name=\\"Model\\" configName=\\"model\\" onInputChange={[Function: mockConstructor]} values={{...}} defaultValue=\\"posenet\\" helpWith=\\"MODEL\\" />
   <Memo() name=\\"FPS\\" configName=\\"fps\\" step={1} defaultValue={30} onValidInput={[Function: mockConstructor]} configParse={[Function: parseInt]} helpWith=\\"FPS\\" />
-<<<<<<< HEAD
   <br />
   <Memo() name=\\"X Sensitivity\\" configName=\\"xSensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"X_SENSITIVITY\\" />
   <Memo() name=\\"Y Sensitivity\\" configName=\\"ySensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"Y_SENSITIVITY\\" />
@@ -19,19 +14,6 @@ exports[`ConfigMenuElement tests should render correctly 1`] = `
   <br />
   <Memo() name=\\"Swap Eyes\\" configName=\\"swapEyes\\" helpWith=\\"SWAP_EYES\\" checked={false} onInputChange={[Function: mockConstructor]} />
   <Memo() name=\\"Toggle Debug\\" configName=\\"toggleDebug\\" helpWith=\\"DEBUG\\" checked={false} onInputChange={[Function: mockConstructor]} />
-  <br />
-  <p data-tip={true} data-for=\\"APP\\">
-    Help
-  </p>
-=======
-  <br />
-  <Memo() name=\\"X Sensitivity\\" configName=\\"xSensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"X_SENSITIVITY\\" />
-  <Memo() name=\\"Y Sensitivity\\" configName=\\"ySensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"Y_SENSITIVITY\\" />
-  <Memo() name=\\"Iris Colour\\" configName=\\"irisColor\\" color=\\"blue\\" onInputChange={[Function: mockConstructor]} helpWith=\\"IRIS_COLOUR\\" />
-  <br />
-  <Memo() name=\\"Swap Eyes\\" configName=\\"swapEyes\\" helpWith=\\"SWAP_EYES\\" checked={false} onInputChange={[Function: mockConstructor]} />
-  <Memo() name=\\"Toggle Debug\\" configName=\\"toggleDebug\\" helpWith=\\"DEBUG\\" checked={false} onInputChange={[Function: mockConstructor]} />
->>>>>>> Added dropdown menu for model to config menu
   <Help problemWith=\\"MODEL\\" />
   <Help problemWith=\\"FPS\\" />
   <Help problemWith=\\"X_SENSITIVITY\\" />

--- a/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
@@ -1,12 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfigMenuElement tests should render correctly 1`] = `
+<<<<<<< HEAD
 "<ConfigMenu width=\\"14em\\" timerLength={1000} window={{...}} debugEnabled={false}>
+=======
+"<ConfigMenu width=\\"14em\\" timerLength={1000} window={{...}}>
+>>>>>>> Added dropdown menu for model to config menu
   <span data-tip={true} data-for=\\"APP\\">
     ?
   </span>
   <Memo() name=\\"Model\\" configName=\\"model\\" onInputChange={[Function: mockConstructor]} values={{...}} defaultValue=\\"posenet\\" helpWith=\\"MODEL\\" />
   <Memo() name=\\"FPS\\" configName=\\"fps\\" step={1} defaultValue={30} onValidInput={[Function: mockConstructor]} configParse={[Function: parseInt]} helpWith=\\"FPS\\" />
+<<<<<<< HEAD
   <br />
   <Memo() name=\\"X Sensitivity\\" configName=\\"xSensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"X_SENSITIVITY\\" />
   <Memo() name=\\"Y Sensitivity\\" configName=\\"ySensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"Y_SENSITIVITY\\" />
@@ -18,6 +23,15 @@ exports[`ConfigMenuElement tests should render correctly 1`] = `
   <p data-tip={true} data-for=\\"APP\\">
     Help
   </p>
+=======
+  <br />
+  <Memo() name=\\"X Sensitivity\\" configName=\\"xSensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"X_SENSITIVITY\\" />
+  <Memo() name=\\"Y Sensitivity\\" configName=\\"ySensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith=\\"Y_SENSITIVITY\\" />
+  <Memo() name=\\"Iris Colour\\" configName=\\"irisColor\\" color=\\"blue\\" onInputChange={[Function: mockConstructor]} helpWith=\\"IRIS_COLOUR\\" />
+  <br />
+  <Memo() name=\\"Swap Eyes\\" configName=\\"swapEyes\\" helpWith=\\"SWAP_EYES\\" checked={false} onInputChange={[Function: mockConstructor]} />
+  <Memo() name=\\"Toggle Debug\\" configName=\\"toggleDebug\\" helpWith=\\"DEBUG\\" checked={false} onInputChange={[Function: mockConstructor]} />
+>>>>>>> Added dropdown menu for model to config menu
   <Help problemWith=\\"MODEL\\" />
   <Help problemWith=\\"FPS\\" />
   <Help problemWith=\\"X_SENSITIVITY\\" />

--- a/src/components/configMenu/ConfigMenuElement.tsx
+++ b/src/components/configMenu/ConfigMenuElement.tsx
@@ -151,10 +151,6 @@ export const ConfigMenuElement = React.memo(
                           );
                       })
                     : null}
-                <br />
-                <p data-tip={true} data-for={HelpWith[HelpWith.APP]}>
-                    Help
-                </p>
 
                 {Object.values(HelpWith).map((type, key: number) => (
                     <Help key={key} problemWith={HelpWith[type] as HelpWith} />

--- a/src/store/actions/config/actions.ts
+++ b/src/store/actions/config/actions.ts
@@ -1,7 +1,7 @@
 import { Action } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { IRootStore } from '../../reducers/rootReducer';
-import { loadModel } from '../detections/actions';
+import { loadModel, restartDetection } from '../detections/actions';
 import {
     ConfigActionTypes,
     ISetConfigPayload,
@@ -14,6 +14,9 @@ export function updateConfigAction(payload: ISetConfigPayload) {
         dispatch(setConfigAction(payload));
         if (payload.partialConfig.model) {
             dispatch(loadModel());
+        }
+        if (payload.partialConfig.fps) {
+            dispatch(restartDetection());
         }
     };
 }


### PR DESCRIPTION
This PR resolves issue #218 to update the fps live without needing to refresh the page. 
It relies heavily on changes implemented as part of #223.

It simply modified the thunk created in #223 to perform the side effect of resetting the interval when the fps is updated.