### PR TITLE
feature/237-config-open-when-debug

### DIFF
--- a/src/__tests__/components/ConfigMenuElement.test.tsx
+++ b/src/__tests__/components/ConfigMenuElement.test.tsx
@@ -27,6 +27,7 @@ describe('ConfigMenuElement tests', () => {
             config,
             window,
             setConfig: jest.fn(),
+            videos: [],
         };
     });
 

--- a/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/ConfigMenuElement.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfigMenuElement tests should render correctly 1`] = `
-"<ConfigMenu width=\\"14em\\" timerLength={1000} window={{...}}>
+"<ConfigMenu width=\\"14em\\" timerLength={1000} window={{...}} debugEnabled={false}>
   <Memo() name=\\"X Sensitivity\\" configName=\\"xSensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith={1} />
   <Memo() name=\\"Y Sensitivity\\" configName=\\"ySensitivity\\" step={0.1} defaultValue={1} onValidInput={[Function: mockConstructor]} configParse={[Function: parseFloat]} helpWith={2} />
   <Memo() name=\\"FPS\\" configName=\\"fps\\" step={1} defaultValue={30} onValidInput={[Function: mockConstructor]} configParse={[Function: parseInt]} helpWith={0} />
@@ -19,5 +19,7 @@ exports[`ConfigMenuElement tests should render correctly 1`] = `
   <Help problemWith={7} />
   <Help problemWith={8} />
   <Help problemWith={9} />
+  <Help problemWith={4} />
+  <Help problemWith={5} />
 </ConfigMenu>"
 `;

--- a/src/components/configMenu/ConfigMenu.tsx
+++ b/src/components/configMenu/ConfigMenu.tsx
@@ -6,6 +6,7 @@ export interface IConfigMenuProps {
     timerLength: number;
     children: React.ReactNode;
     window: Window;
+    debugEnabled: boolean;
 }
 interface IConfigMenuState {
     leftPosition: string;
@@ -30,7 +31,7 @@ export default class ConfigMenu extends React.Component<
     mouseMoveHandler() {
         this.setState({ leftPosition: '0px' });
         clearInterval(this.hideTimeout);
-        if (!this.state.isUnderMouse) {
+        if (!this.state.isUnderMouse && !this.props.debugEnabled) {
             this.hideTimeout = window.setTimeout(
                 () => this.setState({ leftPosition: '-' + this.props.width }),
                 this.props.timerLength,

--- a/src/components/configMenu/ConfigMenuElement.tsx
+++ b/src/components/configMenu/ConfigMenuElement.tsx
@@ -23,20 +23,22 @@ export interface IConfigMenuElementProps {
 
 interface IConfigMenuElementMapStateToProps {
     config: IUserConfig;
-    videoCount: number;
+    videos: Array<HTMLVideoElement | undefined>;
 }
+
 const mapStateToProps = (
     state: IRootStore,
 ): IConfigMenuElementMapStateToProps => {
     return {
         config: getConfig(state),
-        videoCount: getVideos(state).length,
+        videos: getVideos(state),
     };
 };
 
 interface IConfigMenuElementMapDispatchToProps {
     setConfig: (payload: ISetConfigPayload) => void;
 }
+
 const mapDispatchToProps = (dispatch: Dispatch) => {
     return {
         setConfig: (payload: ISetConfigPayload) =>
@@ -50,8 +52,18 @@ export type ConfigMenuElementProps = IConfigMenuElementProps &
 
 export const ConfigMenuElement = React.memo(
     (props: ConfigMenuElementProps) => {
+        const canvasData = [
+            { name: 'Left Camera', helpWith: HelpWith.LEFT_VIDEO_STREAM },
+            { name: 'Right Camera', helpWith: HelpWith.RIGHT_VIDEO_STREAM },
+        ];
+
         return (
-            <ConfigMenu width="14em" timerLength={1000} window={props.window}>
+            <ConfigMenu
+                width="14em"
+                timerLength={1000}
+                window={props.window}
+                debugEnabled={props.config.toggleDebug}
+            >
                 <TextBoxMenuItem
                     name={'X Sensitivity'}
                     configName={'xSensitivity'}
@@ -61,7 +73,6 @@ export const ConfigMenuElement = React.memo(
                     configParse={parseFloat}
                     helpWith={HelpWith.X_SENSITIVITY}
                 />
-
                 <TextBoxMenuItem
                     name={'Y Sensitivity'}
                     configName={'ySensitivity'}
@@ -71,7 +82,6 @@ export const ConfigMenuElement = React.memo(
                     configParse={parseFloat}
                     helpWith={HelpWith.Y_SENSITIVITY}
                 />
-
                 <TextBoxMenuItem
                     name={'FPS'}
                     configName={'fps'}
@@ -81,7 +91,6 @@ export const ConfigMenuElement = React.memo(
                     configParse={parseInt}
                     helpWith={HelpWith.FPS}
                 />
-
                 <CheckBoxMenuItem
                     name={'Swap Eyes'}
                     configName={'swapEyes'}
@@ -89,7 +98,6 @@ export const ConfigMenuElement = React.memo(
                     checked={props.config.swapEyes}
                     onInputChange={props.setConfig}
                 />
-
                 <ColorMenuItem
                     name={'Iris Colour'}
                     configName={'irisColor'}
@@ -97,7 +105,6 @@ export const ConfigMenuElement = React.memo(
                     onInputChange={props.setConfig}
                     helpWith={HelpWith.IRIS_COLOUR}
                 />
-
                 <CheckBoxMenuItem
                     name={'Toggle Debug'}
                     configName={'toggleDebug'}
@@ -106,42 +113,26 @@ export const ConfigMenuElement = React.memo(
                     onInputChange={props.setConfig}
                 />
 
-                {props.config.toggleDebug ? (
-                    props.videoCount > 1 ? (
-                        <>
-                            <CanvasMenuItem
-                                name={'L Camera'}
-                                videoIndex={0}
-                                helpWith={HelpWith.LEFT_VIDEO_STREAM}
-                            />
-                            <CanvasMenuItem
-                                name={'R Camera'}
-                                videoIndex={1}
-                                helpWith={HelpWith.RIGHT_VIDEO_STREAM}
-                            />
-
-                            <Help problemWith={HelpWith.LEFT_VIDEO_STREAM} />
-                            <Help problemWith={HelpWith.RIGHT_VIDEO_STREAM} />
-                        </>
-                    ) : (
-                        <>
-                            <CanvasMenuItem
-                                name={'Camera'}
-                                videoIndex={0}
-                                helpWith={HelpWith.VIDEO_STREAM}
-                            />
-
-                            <Help problemWith={HelpWith.VIDEO_STREAM} />
-                        </>
-                    )
-                ) : null}
-
+                {props.config.toggleDebug
+                    ? props.videos.map((ignore, index, videos) => {
+                          return (
+                              <CanvasMenuItem
+                                  name={
+                                      videos.length === 1
+                                          ? 'Camera'
+                                          : canvasData[index].name
+                                  }
+                                  key={index}
+                                  helpWith={canvasData[index].helpWith}
+                                  videoIndex={index}
+                              />
+                          );
+                      })
+                    : null}
                 <br />
-
                 <p data-tip={true} data-for={HelpWith[HelpWith.APP]}>
                     Help
                 </p>
-
                 <Help problemWith={HelpWith.FPS} />
                 <Help problemWith={HelpWith.X_SENSITIVITY} />
                 <Help problemWith={HelpWith.Y_SENSITIVITY} />
@@ -149,6 +140,8 @@ export const ConfigMenuElement = React.memo(
                 <Help problemWith={HelpWith.IRIS_COLOUR} />
                 <Help problemWith={HelpWith.APP} />
                 <Help problemWith={HelpWith.DEBUG} />
+                <Help problemWith={HelpWith.LEFT_VIDEO_STREAM} />
+                <Help problemWith={HelpWith.RIGHT_VIDEO_STREAM} />
             </ConfigMenu>
         );
     },


### PR DESCRIPTION
This PR resolves #237 that requests keeping the config menu open when debug is checked. 

Additionally, it also refactors the rendering of the webcams so that the label is not displayed when no camera is detected.