### PR TITLE
bug/240-posenet-bounding-box-eyes

### DIFF
--- a/src/__tests__/utils/posenet.test.ts
+++ b/src/__tests__/utils/posenet.test.ts
@@ -7,151 +7,149 @@ const testPose: Pose = {
     keypoints: [
         {
             position: {
-                y: 76.291801452637,
-                x: 253.36747741699,
+                y: 70,
+                x: 250,
             },
             part: 'nose',
-            score: 0.99539834260941,
+            score: 0.9,
         },
         {
             position: {
-                y: 71.10383605957,
-                x: 253.54365539551,
+                y: 75,
+                x: 245,
             },
             part: 'leftEye',
-            score: 0.98781454563141,
+            score: 0.9,
         },
         {
             position: {
-                y: 71.839515686035,
-                x: 246.00454711914,
+                y: 75,
+                x: 255,
             },
             part: 'rightEye',
-            score: 0.99528175592422,
+            score: 0.9,
         },
         {
             position: {
-                y: 72.848854064941,
-                x: 263.08151245117,
+                y: 75,
+                x: 265,
             },
             part: 'leftEar',
-            score: 0.84029853343964,
+            score: 0.9,
         },
         {
             position: {
-                y: 79.956565856934,
-                x: 234.26812744141,
+                y: 75,
+                x: 235,
             },
             part: 'rightEar',
-            score: 0.92544466257095,
+            score: 0.9,
         },
         {
             position: {
-                y: 98.34538269043,
-                x: 399.64068603516,
+                y: 100,
+                x: 400,
             },
             part: 'leftShoulder',
-            score: 0.99559044837952,
+            score: 0.9,
         },
         {
             position: {
-                y: 95.082359313965,
-                x: 458.21868896484,
+                y: 100,
+                x: 460,
             },
             part: 'rightShoulder',
-            score: 0.99583911895752,
+            score: 0.9,
         },
         {
             position: {
-                y: 94.626205444336,
-                x: 163.94561767578,
+                y: 95,
+                x: 160,
             },
             part: 'leftElbow',
-            score: 0.9518963098526,
+            score: 0.9,
         },
         {
             position: {
-                y: 150.2349395752,
-                x: 245.06030273438,
+                y: 150,
+                x: 245,
             },
             part: 'rightElbow',
-            score: 0.98052614927292,
+            score: 0.9,
         },
         {
             position: {
-                y: 113.9603729248,
-                x: 393.19735717773,
+                y: 100,
+                x: 400,
             },
             part: 'leftWrist',
-            score: 0.94009721279144,
+            score: 0.9,
         },
         {
             position: {
-                y: 186.47859191895,
-                x: 257.98034667969,
+                y: 200,
+                x: 250,
             },
             part: 'rightWrist',
-            score: 0.98029226064682,
+            score: 0.9,
         },
         {
             position: {
-                y: 208.5266418457,
-                x: 284.46710205078,
+                y: 200,
+                x: 280,
             },
             part: 'leftHip',
-            score: 0.97870296239853,
+            score: 0.9,
         },
         {
             position: {
-                y: 209.9910736084,
-                x: 243.31219482422,
+                y: 200,
+                x: 240,
             },
             part: 'rightHip',
-            score: 0.97424703836441,
+            score: 0.9,
         },
         {
             position: {
-                y: 281.61965942383,
-                x: 310.93188476562,
+                y: 280,
+                x: 300,
             },
             part: 'leftKnee',
-            score: 0.98368924856186,
+            score: 0.9,
         },
         {
             position: {
-                y: 282.80120849609,
-                x: 203.81164550781,
+                y: 280,
+                x: 200,
             },
             part: 'rightKnee',
-            score: 0.96947449445724,
+            score: 0.9,
         },
         {
             position: {
-                y: 360.62716674805,
-                x: 292.21047973633,
+                y: 350,
+                x: 290,
             },
             part: 'leftAnkle',
-            score: 0.8883239030838,
+            score: 0.9,
         },
         {
             position: {
-                y: 347.41177368164,
-                x: 203.88229370117,
+                y: 350,
+                x: 200,
             },
             part: 'rightAnkle',
-            score: 0.8255187869072,
+            score: 0.9,
         },
     ],
 };
 
 const testInput = [testPose];
 
-const box = getBoundingBox(testPose.keypoints.slice(0, 2));
-
 const testOutput: Detection[] = [
     {
         model: DetectionModelType.Posenet,
-        bbox: [box.minX, box.minY, box.maxX - box.minX, box.maxY - box.minY],
+        bbox: [245, 75, 10, 0],
         info: testPose,
     },
 ];

--- a/src/utils/objectDetection/posenet.ts
+++ b/src/utils/objectDetection/posenet.ts
@@ -19,7 +19,7 @@ export default class Posenet implements IObjectDetector {
 
     static reshapeDetections(detections: posenet.Pose[]): Detection[] {
         return detections.map(detection => {
-            const box = posenet.getBoundingBox(detection.keypoints.slice(0, 2)); // 0-2 correspond nose and eyes
+            const box = posenet.getBoundingBox(detection.keypoints.slice(1, 3)); // 1 and 2 correspond nose and eyes
             return {
                 model: DetectionModelType.Posenet,
                 bbox: [

--- a/src/utils/objectDetection/posenet.ts
+++ b/src/utils/objectDetection/posenet.ts
@@ -19,7 +19,7 @@ export default class Posenet implements IObjectDetector {
 
     static reshapeDetections(detections: posenet.Pose[]): Detection[] {
         return detections.map(detection => {
-            const box = posenet.getBoundingBox(detection.keypoints.slice(1, 3)); // 1 and 2 correspond nose and eyes
+            const box = posenet.getBoundingBox(detection.keypoints.slice(1, 3)); // 1 and 2 correspond to left and right eye
             return {
                 model: DetectionModelType.Posenet,
                 bbox: [


### PR DESCRIPTION
Minor bug fix for #240 to draw bounding boxes around eyes only, instead of left eye and nose. This bug was caused by not considering that `Array.prototype.slice()` excludes the end argument. 