### PR TITLE
Refactor/238 improve performance of calculatebrightness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ const mapDispatchToProps = (
     dispatch: ThunkDispatch<IRootStore, void, Action>,
     ownProps: IAppProps,
 ) => ({
-    loadModel: () => dispatch(loadModel(ownProps.window.document)),
+    loadModel: () => dispatch(loadModel(ownProps.environment.document)),
 });
 
 export default connect(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,6 @@ export class App extends React.Component<AppProps, IAppState> {
                     ) : (
                         <div>
                             <MovementHandler
-                                document={document}
                                 width={this.state.width}
                                 height={this.state.height}
                                 environment={this.props.environment}
@@ -117,8 +116,9 @@ const mapStateToProps = (state: IRootStore): IAppMapStateToProps => ({
 
 const mapDispatchToProps = (
     dispatch: ThunkDispatch<IRootStore, void, Action>,
+    ownProps: IAppProps,
 ) => ({
-    loadModel: () => dispatch(loadModel()),
+    loadModel: () => dispatch(loadModel(ownProps.window.document)),
 });
 
 export default connect(

--- a/src/__tests__/reducers/video/videoReducer.test.ts
+++ b/src/__tests__/reducers/video/videoReducer.test.ts
@@ -1,3 +1,5 @@
+import { EyeSide } from '../../../AppConstants';
+import { setImageDataAction } from '../../../store/actions/video/actions';
 import {
     IVideo,
     IVideoState,

--- a/src/__tests__/reducers/video/videoReducer.test.ts
+++ b/src/__tests__/reducers/video/videoReducer.test.ts
@@ -39,7 +39,7 @@ let mockStore: IVideoState;
 describe('Video Reducer', () => {
     beforeEach(() => {
         mockStore = videoStore(
-            { videos: {}, webcamAvailable: false },
+            { videos: {}, webcamAvailable: false, images: {} },
             { type: SET_VIDEO_STREAMS, videos: mockInitialState },
         );
     });
@@ -48,6 +48,7 @@ describe('Video Reducer', () => {
         const expectedState: IVideoState = {
             videos: mockInitialState,
             webcamAvailable: false,
+            images: {},
         };
         expect(mockStore).toEqual(expectedState);
     });
@@ -63,6 +64,7 @@ describe('Video Reducer', () => {
                 testDevice2: testDevice2Video,
             },
             webcamAvailable: false,
+            images: {},
         };
         expect(newState).toEqual(expectedState);
     });

--- a/src/__tests__/reducers/video/videoSelectors.test.ts
+++ b/src/__tests__/reducers/video/videoSelectors.test.ts
@@ -36,7 +36,7 @@ let mockVideoStore: IVideoState;
 describe('Video Selectors', () => {
     beforeEach(() => {
         mockVideoStore = videoStore(
-            { videos: {}, webcamAvailable: false },
+            { videos: {}, webcamAvailable: false, images: {} },
             { type: SET_VIDEO_STREAMS, videos: mockTwoVideoStreams },
         );
         mockRootStore = {

--- a/src/components/configMenu/ConfigMenuElement.tsx
+++ b/src/components/configMenu/ConfigMenuElement.tsx
@@ -8,7 +8,7 @@ import { ISetConfigPayload } from '../../store/actions/config/types';
 import { IRootStore } from '../../store/reducers/rootReducer';
 import { getConfig } from '../../store/selectors/configSelectors';
 import { getVideos } from '../../store/selectors/videoSelectors';
-import ConfigMenu from './ConfigMenu';
+import ConfigMenu, { IConfigMenuProps } from './ConfigMenu';
 import Help, { HelpWith } from './Help';
 import IUserConfig from './IUserConfig';
 import CanvasMenuItem from './menuItems/CanvasMenuItem';
@@ -125,9 +125,10 @@ const mapStateToProps = (
 
 const mapDispatchToProps = (
     dispatch: ThunkDispatch<IRootStore, void, Action>,
+    ownProps: IConfigMenuProps,
 ) => ({
     setConfig: (payload: ISetConfigPayload) =>
-        dispatch(updateConfigAction(payload)),
+        dispatch(updateConfigAction(payload, ownProps.window.document)),
 });
 
 export default connect(

--- a/src/components/configMenu/ConfigMenuElement.tsx
+++ b/src/components/configMenu/ConfigMenuElement.tsx
@@ -8,7 +8,7 @@ import { ISetConfigPayload } from '../../store/actions/config/types';
 import { IRootStore } from '../../store/reducers/rootReducer';
 import { getConfig } from '../../store/selectors/configSelectors';
 import { getVideos } from '../../store/selectors/videoSelectors';
-import ConfigMenu, { IConfigMenuProps } from './ConfigMenu';
+import ConfigMenu from './ConfigMenu';
 import Help, { HelpWith } from './Help';
 import IUserConfig from './IUserConfig';
 import CanvasMenuItem from './menuItems/CanvasMenuItem';
@@ -125,7 +125,7 @@ const mapStateToProps = (
 
 const mapDispatchToProps = (
     dispatch: ThunkDispatch<IRootStore, void, Action>,
-    ownProps: IConfigMenuProps,
+    ownProps: IConfigMenuElementProps,
 ) => ({
     setConfig: (payload: ISetConfigPayload) =>
         dispatch(updateConfigAction(payload, ownProps.window.document)),

--- a/src/components/eye/EyeUtils.ts
+++ b/src/components/eye/EyeUtils.ts
@@ -18,21 +18,16 @@ export function checkLight(
         | HTMLCanvasElement
         | HTMLVideoElement
         | null,
-    analyse: (
-        canvas: HTMLCanvasElement,
-        tooBright: boolean,
-    ) => { tooBright: boolean; scaledPupilSize: number },
 ): { tooBright: boolean; scaledPupilSize: number } {
     if (video && video instanceof HTMLVideoElement) {
         const canvas = doc.createElement('canvas');
         canvas.height = video.height;
         canvas.width = video.width;
         const canvasCtx = canvas.getContext('2d');
-
         if (canvasCtx) {
             canvasCtx.drawImage(video, 0, 0, canvas.width, canvas.height);
         }
-        return analyse(canvas, tooBright);
+        return analyseLight(canvas, tooBright);
     }
     return { tooBright: false, scaledPupilSize: 0 };
 }
@@ -45,17 +40,13 @@ export function analyseLight(
 
     if (ctx && canvas.width > 0) {
         const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-
         const data = imageData.data;
-
         let colorSum = 0;
-
         for (let i = 0; i < data.length; i += 4) {
             const avg = Math.floor((data[i] + data[i + 1] + data[i + 2]) / 3);
 
             colorSum += avg;
         }
-
         let brightness = Math.floor(colorSum / (canvas.width * canvas.height));
 
         if (brightness > maxBrightness) {
@@ -64,7 +55,6 @@ export function analyseLight(
         } else if (tooBright) {
             tooBright = false;
         }
-
         const scaledPupilSize =
             ((maxBrightness - brightness) / maxBrightness) * dilationMultipler +
             dilationOffset;

--- a/src/components/eye/EyeUtils.ts
+++ b/src/components/eye/EyeUtils.ts
@@ -9,45 +9,19 @@ import {
     xIncrement,
 } from '../../AppConstants';
 
-export function checkLight(
-    doc: Document,
-    tooBright: boolean,
-    video:
-        | ImageData
-        | HTMLImageElement
-        | HTMLCanvasElement
-        | HTMLVideoElement
-        | null,
-): { tooBright: boolean; scaledPupilSize: number } {
-    if (video && video instanceof HTMLVideoElement) {
-        const canvas = doc.createElement('canvas');
-        canvas.height = video.height;
-        canvas.width = video.width;
-        const canvasCtx = canvas.getContext('2d');
-        if (canvasCtx) {
-            canvasCtx.drawImage(video, 0, 0, canvas.width, canvas.height);
-        }
-        return analyseLight(canvas, tooBright);
-    }
-    return { tooBright: false, scaledPupilSize: 0 };
-}
-
 export function analyseLight(
-    canvas: HTMLCanvasElement,
+    image: ImageData,
     tooBright: boolean,
 ): { tooBright: boolean; scaledPupilSize: number } {
-    const ctx = canvas.getContext('2d');
-
-    if (ctx && canvas.width > 0) {
-        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-        const data = imageData.data;
+    if (image.width > 0) {
+        const data = image.data;
         let colorSum = 0;
         for (let i = 0; i < data.length; i += 4) {
             const avg = Math.floor((data[i] + data[i + 1] + data[i + 2]) / 3);
 
             colorSum += avg;
         }
-        let brightness = Math.floor(colorSum / (canvas.width * canvas.height));
+        let brightness = Math.floor(colorSum / (image.width * image.height));
 
         if (brightness > maxBrightness) {
             tooBright = true;

--- a/src/components/intelligentMovement/MovementHandler.tsx
+++ b/src/components/intelligentMovement/MovementHandler.tsx
@@ -22,7 +22,6 @@ import EyeController from '../eye/EyeController';
 import { analyseLight, naturalMovement } from '../eye/EyeUtils';
 
 interface IMovementProps {
-    document: Document;
     width: number;
     height: number;
     environment: Window;
@@ -86,7 +85,7 @@ export class MovementHandler extends React.Component<
     }
 
     componentDidMount() {
-        this.movementInterval = window.setInterval(
+        this.movementInterval = this.props.environment.setInterval(
             this.animateEye,
             1000 / this.props.fps,
             this.prevProps,
@@ -114,7 +113,7 @@ export class MovementHandler extends React.Component<
     }
 
     componentWillUnmount() {
-        clearInterval(this.movementInterval);
+        this.props.environment.clearInterval(this.movementInterval);
     }
 
     calculateBrightness() {
@@ -238,6 +237,7 @@ const mapStateToProps = (state: IRootStore) => ({
     detections: state.detectionStore.detections,
     target: getTargets(state),
     openCoefficient: state.detectionStore.eyesOpenCoefficient,
+    images: state.videoStore.images,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): IDispatchProps => ({

--- a/src/components/intelligentMovement/MovementHandler.tsx
+++ b/src/components/intelligentMovement/MovementHandler.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import {
     eyelidPosition,
+    EyeSide,
     maxMoveWithoutBlink,
     pupilSizes,
     sleepDelay,
@@ -15,11 +16,10 @@ import {
 } from '../../store/actions/detections/types';
 import { IRootStore } from '../../store/reducers/rootReducer';
 import { getTargets } from '../../store/selectors/detectionSelectors';
-import { getVideos } from '../../store/selectors/videoSelectors';
 import { ICoords } from '../../utils/types';
 import { getLargerDistance } from '../../utils/utils';
 import EyeController from '../eye/EyeController';
-import { checkLight, naturalMovement } from '../eye/EyeUtils';
+import { analyseLight, naturalMovement } from '../eye/EyeUtils';
 
 interface IMovementProps {
     document: Document;
@@ -32,8 +32,8 @@ interface IStateProps {
     fps: number;
     detections: IDetection[];
     target: ICoords;
-    videos: Array<HTMLVideoElement | undefined>;
     openCoefficient: number;
+    images: { [key: string]: ImageData };
 }
 
 interface IDispatchProps {
@@ -118,11 +118,10 @@ export class MovementHandler extends React.Component<
     }
 
     calculateBrightness() {
-        if (this.props.videos[0]) {
-            const { tooBright, scaledPupilSize } = checkLight(
-                this.props.environment.document,
+        if (this.props.images[EyeSide.LEFT]) {
+            const { tooBright, scaledPupilSize } = analyseLight(
+                this.props.images[EyeSide.LEFT],
                 this.tooBright,
-                this.props.videos[0] as HTMLVideoElement,
             );
             if (tooBright) {
                 this.tooBright = true;
@@ -239,7 +238,6 @@ const mapStateToProps = (state: IRootStore) => ({
     detections: state.detectionStore.detections,
     target: getTargets(state),
     openCoefficient: state.detectionStore.eyesOpenCoefficient,
-    videos: getVideos(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): IDispatchProps => ({

--- a/src/components/intelligentMovement/MovementHandler.tsx
+++ b/src/components/intelligentMovement/MovementHandler.tsx
@@ -19,7 +19,7 @@ import { getVideos } from '../../store/selectors/videoSelectors';
 import { ICoords } from '../../utils/types';
 import { getLargerDistance } from '../../utils/utils';
 import EyeController from '../eye/EyeController';
-import { analyseLight, checkLight, naturalMovement } from '../eye/EyeUtils';
+import { checkLight, naturalMovement } from '../eye/EyeUtils';
 
 interface IMovementProps {
     document: Document;
@@ -123,9 +123,7 @@ export class MovementHandler extends React.Component<
                 this.props.environment.document,
                 this.tooBright,
                 this.props.videos[0] as HTMLVideoElement,
-                analyseLight,
             );
-
             if (tooBright) {
                 this.tooBright = true;
                 this.props.setOpen(eyelidPosition.CLOSED);

--- a/src/store/actions/config/actions.ts
+++ b/src/store/actions/config/actions.ts
@@ -9,11 +9,14 @@ import {
     UPDATE_CONFIG,
 } from './types';
 
-export function updateConfigAction(payload: ISetConfigPayload) {
+export function updateConfigAction(
+    payload: ISetConfigPayload,
+    document: Document,
+) {
     return (dispatch: ThunkDispatch<IRootStore, void, Action>) => {
         dispatch(setConfigAction(payload));
         if (payload.partialConfig.fps) {
-            dispatch(restartDetection());
+            dispatch(restartDetection(document));
         }
     };
 }

--- a/src/store/actions/detections/actions.ts
+++ b/src/store/actions/detections/actions.ts
@@ -30,16 +30,16 @@ export function setModel(model: posenet.PoseNet | null): ISetModelAction {
     };
 }
 
-export function loadModel() {
+export function loadModel(document: Document) {
     return async (dispatch: ThunkDispatch<IRootStore, void, Action>) => {
         dispatch(setModel(null));
         const model = await posenet.load();
         dispatch(setModel(model));
-        dispatch(restartDetection());
+        dispatch(restartDetection(document));
     };
 }
 
-export function restartDetection() {
+export function restartDetection(document: Document) {
     return (
         dispatch: ThunkDispatch<IRootStore, void, Action>,
         getState: () => IRootStore,
@@ -47,14 +47,14 @@ export function restartDetection() {
         const state = getState();
         clearInterval(state.detectionStore.detectionInterval);
         const id = setInterval(
-            () => dispatch(handleDetection()),
+            () => dispatch(handleDetection(document)),
             1000 / state.configStore.config.fps,
         );
         dispatch({ type: 'SET_INTERVAL', payload: id });
     };
 }
 
-export function handleDetection() {
+export function handleDetection(document: Document) {
     return async (
         dispatch: ThunkDispatch<IRootStore, void, Action>,
         getState: () => IRootStore,
@@ -67,7 +67,7 @@ export function handleDetection() {
             return;
         }
 
-        const images = getImageDataFromVideos(videos);
+        const images = getImageDataFromVideos(videos, document);
         dispatch(setImageDataAction(images));
 
         let left: IDetection[] = [];

--- a/src/store/actions/video/actions.ts
+++ b/src/store/actions/video/actions.ts
@@ -5,6 +5,7 @@ import { IRootStore } from '../../reducers/rootReducer';
 import {
     ISetVideoPayload,
     IVideo,
+    SET_IMAGE_DATA,
     SET_VIDEO,
     SET_VIDEO_STREAMS,
     TOGGLE_WEBCAM_AVAILABLE,
@@ -48,5 +49,12 @@ export function setStream(mediaDevices: MediaDevices) {
         ) {
             dispatch(toggleWebcamAvailable());
         }
+    };
+}
+
+export function setImageDataAction(images: ImageData[]): VideoActionTypes {
+    return {
+        type: SET_IMAGE_DATA,
+        images,
     };
 }

--- a/src/store/actions/video/actions.ts
+++ b/src/store/actions/video/actions.ts
@@ -52,7 +52,9 @@ export function setStream(mediaDevices: MediaDevices) {
     };
 }
 
-export function setImageDataAction(images: ImageData[]): VideoActionTypes {
+export function setImageDataAction(images: {
+    [key: string]: ImageData;
+}): VideoActionTypes {
     return {
         type: SET_IMAGE_DATA,
         images,

--- a/src/store/actions/video/types.ts
+++ b/src/store/actions/video/types.ts
@@ -1,7 +1,7 @@
 export const SET_VIDEO = 'SET_VIDEO';
 export const SET_VIDEO_STREAMS = 'SET_VIDEO_STREAMS';
-export const CLEAR_STATE = 'CLEAR_STATE';
 export const TOGGLE_WEBCAM_AVAILABLE = 'TOGGLE_WEBCAM_AVAILABLE';
+export const SET_IMAGE_DATA = 'SET_IMAGE_DATA';
 
 export interface IVideo {
     deviceId: string;
@@ -14,6 +14,7 @@ export interface IVideo {
 export interface IVideoState {
     webcamAvailable: boolean;
     videos: { [deviceId: string]: IVideo };
+    images: ImageData[];
 }
 
 export interface ISetVideoPayload {
@@ -35,7 +36,13 @@ interface IToggleWebcamAvailable {
     type: typeof TOGGLE_WEBCAM_AVAILABLE;
 }
 
+interface ISetImageDataAction {
+    type: typeof SET_IMAGE_DATA;
+    images: ImageData[];
+}
+
 export type VideoActionTypes =
     | ISetVideoAction
     | ISetVideoStreamsAction
-    | IToggleWebcamAvailable;
+    | IToggleWebcamAvailable
+    | ISetImageDataAction;

--- a/src/store/actions/video/types.ts
+++ b/src/store/actions/video/types.ts
@@ -14,7 +14,7 @@ export interface IVideo {
 export interface IVideoState {
     webcamAvailable: boolean;
     videos: { [deviceId: string]: IVideo };
-    images: ImageData[];
+    images: { [key: string]: ImageData };
 }
 
 export interface ISetVideoPayload {
@@ -38,7 +38,9 @@ interface IToggleWebcamAvailable {
 
 interface ISetImageDataAction {
     type: typeof SET_IMAGE_DATA;
-    images: ImageData[];
+    images: {
+        [key: string]: ImageData;
+    };
 }
 
 export type VideoActionTypes =

--- a/src/store/reducers/videoReducer.ts
+++ b/src/store/reducers/videoReducer.ts
@@ -1,6 +1,7 @@
 import {
     IVideo,
     IVideoState,
+    SET_IMAGE_DATA,
     SET_VIDEO,
     SET_VIDEO_STREAMS,
     TOGGLE_WEBCAM_AVAILABLE,
@@ -10,6 +11,7 @@ import {
 export const initialState: IVideoState = {
     webcamAvailable: false,
     videos: {},
+    images: [],
 };
 
 const videoStore = (
@@ -42,6 +44,11 @@ const videoStore = (
             return {
                 ...state,
                 webcamAvailable: !state.webcamAvailable,
+            };
+        case SET_IMAGE_DATA:
+            return {
+                ...state,
+                ...action,
             };
         default:
             return state;

--- a/src/store/reducers/videoReducer.ts
+++ b/src/store/reducers/videoReducer.ts
@@ -11,7 +11,7 @@ import {
 export const initialState: IVideoState = {
     webcamAvailable: false,
     videos: {},
-    images: [],
+    images: {},
 };
 
 const videoStore = (
@@ -48,7 +48,10 @@ const videoStore = (
         case SET_IMAGE_DATA:
             return {
                 ...state,
-                ...action,
+                images: {
+                    ...state.images,
+                    ...action.images,
+                },
             };
         default:
             return state;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -35,13 +35,14 @@ export function reshapeDetections(detections: Pose[]): IDetection[] {
 
 export function getImageDataFromVideos(
     videos: Array<HTMLVideoElement | undefined>,
+    document: Document,
 ): { [key: string]: ImageData } {
     let images: { [key: string]: ImageData } = {};
-    const leftImage = getImageData(videos[0]);
+    const leftImage = getImageData(videos[0], document);
     if (leftImage) {
         images = { [EyeSide.LEFT]: leftImage };
         if (videos[1]) {
-            const rightImage = getImageData(videos[1]);
+            const rightImage = getImageData(videos[1], document);
             if (rightImage) {
                 images[EyeSide.RIGHT] = rightImage;
             }
@@ -50,7 +51,10 @@ export function getImageDataFromVideos(
     return images;
 }
 
-function getImageData(video: HTMLVideoElement | undefined): ImageData | null {
+function getImageData(
+    video: HTMLVideoElement | undefined,
+    document: Document,
+): ImageData | null {
     if (video) {
         const canvas = document.createElement('canvas');
         canvas.height = video.height;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { getBoundingBox, partIds, Pose } from '@tensorflow-models/posenet';
+import { EyeSide } from '../AppConstants';
 import { IDetection } from '../models/objectDetection';
 import { Bbox, ICoords } from './types';
 
@@ -30,4 +31,35 @@ export function reshapeDetections(detections: Pose[]): IDetection[] {
             info: detection,
         };
     });
+}
+
+export function getImageDataFromVideos(
+    videos: Array<HTMLVideoElement | undefined>,
+): { [key: string]: ImageData } {
+    let images: { [key: string]: ImageData } = {};
+    const leftImage = getImageData(videos[0]);
+    if (leftImage) {
+        images = { [EyeSide.LEFT]: leftImage };
+        if (videos[1]) {
+            const rightImage = getImageData(videos[1]);
+            if (rightImage) {
+                images[EyeSide.RIGHT] = rightImage;
+            }
+        }
+    }
+    return images;
+}
+
+function getImageData(video: HTMLVideoElement | undefined): ImageData | null {
+    if (video) {
+        const canvas = document.createElement('canvas');
+        canvas.height = video.height;
+        canvas.width = video.width;
+        const canvasCtx = canvas.getContext('2d');
+        if (canvasCtx) {
+            canvasCtx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            return canvasCtx.getImageData(0, 0, canvas.width, canvas.height);
+        }
+    }
+    return null;
 }


### PR DESCRIPTION
This PR is to reduce the number of calls to canvas context getImageData. We only call it once in analyseLight in EyeUtils, but when passing HTMLVideoElement to the Posenet model, the same is done in tensorflow. Since this operation is time consuming (~40ms), the getImageData has been moved to handleDetection action and the ImageData object saved in store for use in Posenet and analyseLight.