### PR TITLE
Refactor/300 remove open coefficient

### DIFF
--- a/src/AppConstants.ts
+++ b/src/AppConstants.ts
@@ -69,4 +69,5 @@ export const targetingConsts = {
     maxInterval: 7000,
     maxNum: 8,
 };
+export const minPoseConfidence = 0.2;
 export const irisSkewFactor = 0.8; // factor by which to squish iris when iris is all the way to edge of sclera

--- a/src/__tests__/reducers/config/configReducer.test.ts
+++ b/src/__tests__/reducers/config/configReducer.test.ts
@@ -18,6 +18,8 @@ describe('Config Reducer tests', () => {
         toggleDebug: false,
         modelConfig: initalModelConfig,
         detectionConfig: initialDetectionConfig,
+        toggleReflection: false,
+        reflectionOpacity: 0,
     };
     it('update config with partial state, so some values are updated and others are as they were before', () => {
         const partialConfig = { fps: 555, toggleDebug: true, irisColor: 'red' };
@@ -33,6 +35,8 @@ describe('Config Reducer tests', () => {
             toggleDebug: true,
             modelConfig: initalModelConfig,
             detectionConfig: initialDetectionConfig,
+            toggleReflection: false,
+            reflectionOpacity: 0,
         };
         expect(configStore(testState, setAction)).toStrictEqual(alteredState);
     });

--- a/src/components/eye/EyeController.tsx
+++ b/src/components/eye/EyeController.tsx
@@ -14,10 +14,7 @@ import { setAnimation } from '../../store/actions/detections/actions';
 import { ISetAnimationAction } from '../../store/actions/detections/types';
 import { IRootStore } from '../../store/reducers/rootReducer';
 import { getConfig } from '../../store/selectors/configSelectors';
-import {
-    getOpenCoefficient,
-    getTargets,
-} from '../../store/selectors/detectionSelectors';
+import { getTargets } from '../../store/selectors/detectionSelectors';
 import { getVideos } from '../../store/selectors/videoSelectors';
 import { Animation } from '../../utils/pose/animations';
 import { ICoords } from '../../utils/types';
@@ -32,13 +29,13 @@ interface IEyeControllerProps {
     environment: Window;
     dilation: number;
     detected: boolean;
+    openCoefficient: number;
 }
 
 interface IEyeControllerMapStateToProps {
     config: IConfigState;
     target: ICoords;
     videos: Array<HTMLVideoElement | undefined>;
-    openCoefficient: number;
     animation: Animation;
 }
 
@@ -222,7 +219,6 @@ const mapStateToProps = (state: IRootStore): IEyeControllerMapStateToProps => ({
     config: getConfig(state),
     target: getTargets(state),
     videos: getVideos(state),
-    openCoefficient: getOpenCoefficient(state),
     animation: state.detectionStore.animation,
 });
 

--- a/src/components/intelligentMovement/MovementHandler.tsx
+++ b/src/components/intelligentMovement/MovementHandler.tsx
@@ -9,14 +9,14 @@ import {
     pupilSizes,
 } from '../../AppConstants';
 import { IDetection } from '../../models/objectDetection';
-import { setIdleTarget, setOpen } from '../../store/actions/detections/actions';
-import {
-    ISetIdleTargetAction,
-    ISetOpenAction,
-} from '../../store/actions/detections/types';
+import { setIdleTarget } from '../../store/actions/detections/actions';
+import { ISetIdleTargetAction } from '../../store/actions/detections/types';
 import { IRootStore } from '../../store/reducers/rootReducer';
 import { getFPS } from '../../store/selectors/configSelectors';
-import { getTargets } from '../../store/selectors/detectionSelectors';
+import {
+    getDetections,
+    getTargets,
+} from '../../store/selectors/detectionSelectors';
 import { Animation } from '../../utils/pose/animations';
 import { ICoords } from '../../utils/types';
 import { getLargerDistance } from '../../utils/utils';
@@ -33,14 +33,12 @@ interface IStateProps {
     fps: number;
     detections: IDetection[];
     target: ICoords;
-    openCoefficient: number;
     images: { [key: string]: ImageData };
     animation: Animation;
 }
 
 interface IDispatchProps {
     setIdleTarget: (coords: ICoords) => ISetIdleTargetAction;
-    setOpen: (openCoefficient: number) => ISetOpenAction;
 }
 
 interface IMovementState {
@@ -62,6 +60,7 @@ export class MovementHandler extends React.Component<
     private squinting: boolean;
     private personDetected: boolean;
     private prevProps: MovementHandlerProps | null;
+    private openCoefficient: number;
 
     constructor(props: MovementHandlerProps) {
         super(props);
@@ -77,6 +76,7 @@ export class MovementHandler extends React.Component<
         this.personDetected = false;
         this.squinting = false;
         this.prevProps = null;
+        this.openCoefficient = eyelidPosition.OPEN;
 
         this.animateEye = this.animateEye.bind(this);
         this.isNewTarget = this.isNewTarget.bind(this);
@@ -100,7 +100,6 @@ export class MovementHandler extends React.Component<
             this.props.animation.length === 0 &&
             (this.props.height !== nextProps.height ||
                 this.props.width !== nextProps.width ||
-                this.props.openCoefficient !== nextProps.openCoefficient ||
                 this.props.target !== nextProps.target ||
                 this.props.detections !== nextProps.detections)
         );
@@ -128,10 +127,10 @@ export class MovementHandler extends React.Component<
             );
             if (tooBright) {
                 this.tooBright = true;
-                this.props.setOpen(eyelidPosition.CLOSED);
+                this.openCoefficient = eyelidPosition.CLOSED;
             } else if (this.tooBright) {
                 this.tooBright = false;
-                this.props.setOpen(eyelidPosition.OPEN);
+                this.openCoefficient = eyelidPosition.OPEN;
             }
             this.setState({ dilationCoefficient: scaledPupilSize });
         }
@@ -140,14 +139,14 @@ export class MovementHandler extends React.Component<
     checkSelection() {
         if (this.squinting && Math.random() < 0.1) {
             this.squinting = false;
-            this.props.setOpen(eyelidPosition.OPEN);
+            this.openCoefficient = eyelidPosition.OPEN;
         }
 
         if (this.props.detections.length > 0) {
             this.wake();
 
             if (this.squinting) {
-                this.props.setOpen(eyelidPosition.OPEN);
+                this.openCoefficient = eyelidPosition.OPEN;
             }
 
             this.isNewTarget();
@@ -181,7 +180,7 @@ export class MovementHandler extends React.Component<
             );
 
             if (leftEyeDist > blinkConsts.movementThreshold) {
-                this.props.setOpen(eyelidPosition.CLOSED);
+                this.openCoefficient = eyelidPosition.CLOSED;
             }
         }
     }
@@ -202,7 +201,7 @@ export class MovementHandler extends React.Component<
             this.setState({
                 dilationCoefficient: pupilSizes.constricted,
             });
-            this.props.setOpen(eyelidPosition.SQUINT);
+            this.openCoefficient = eyelidPosition.SQUINT;
             this.props.setIdleTarget({ x: 0, y: 0 });
         }
     }
@@ -211,14 +210,14 @@ export class MovementHandler extends React.Component<
         if (this.sleepTimeout !== null) {
             clearTimeout(this.sleepTimeout);
             this.sleepTimeout = null;
-            this.props.setOpen(eyelidPosition.OPEN);
+            this.openCoefficient = eyelidPosition.OPEN;
         }
     }
 
     sleep() {
         if (this.sleepTimeout === null) {
             this.sleepTimeout = setTimeout(() => {
-                this.props.setOpen(eyelidPosition.CLOSED);
+                this.openCoefficient = eyelidPosition.CLOSED;
             }, intervals.sleep);
         }
     }
@@ -230,6 +229,7 @@ export class MovementHandler extends React.Component<
                 height={this.props.height}
                 environment={this.props.environment}
                 dilation={this.state.dilationCoefficient}
+                openCoefficient={this.openCoefficient}
                 detected={this.personDetected}
             />
         );
@@ -238,16 +238,14 @@ export class MovementHandler extends React.Component<
 
 const mapStateToProps = (state: IRootStore) => ({
     fps: getFPS(state),
-    detections: state.detectionStore.detections,
+    detections: getDetections(state),
     target: getTargets(state),
-    openCoefficient: state.detectionStore.eyesOpenCoefficient,
     images: state.videoStore.images,
     animation: state.detectionStore.animation,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): IDispatchProps => ({
     setIdleTarget: (coords: ICoords) => dispatch(setIdleTarget(coords)),
-    setOpen: (openCoefficient: number) => dispatch(setOpen(openCoefficient)),
 });
 
 export default connect(

--- a/src/utils/pose/poseDetection.ts
+++ b/src/utils/pose/poseDetection.ts
@@ -1,5 +1,5 @@
 import { Keypoint, partIds } from '@tensorflow-models/posenet';
-import { minConfidence, Pose } from '../../AppConstants';
+import { minPoseConfidence, Pose } from '../../AppConstants';
 import { IDetection } from '../../models/objectDetection';
 
 const poseMapping: { [key: string]: (selection: IDetection) => boolean } = {
@@ -205,5 +205,5 @@ function armPointingUp(wrist: Keypoint, elbow: Keypoint, shoulder: Keypoint) {
 }
 
 function checkKeypoints(...points: Keypoint[]): boolean {
-    return !points.some(point => point.score < minConfidence);
+    return !points.some(point => point.score < minPoseConfidence);
 }


### PR DESCRIPTION
This PR addresses #300 in regard to removing the `setOpen` action and associated `openCoefficient` from global state.

As the `movementHandler` derives the openCoefficient, and all components that use this are children of `movementHandler`, it makes sense to just pass this value as a prop.