### PR TITLE
feature/317 better swapping

### DIFF
--- a/src/components/eye/Eye.tsx
+++ b/src/components/eye/Eye.tsx
@@ -24,7 +24,7 @@ export interface IEyeProps {
         scaledXcontrolOffset: number;
         scaledYcontrolOffset: number;
     };
-    eyeCoords: {
+    eyeShape: {
         leftX: number;
         rightX: number;
         middleY: number;
@@ -71,13 +71,13 @@ export default function Eye(props: IEyeProps) {
             />
             <Eyelids
                 transitionStyle={eyelidTransitionStyle}
-                eyeCoords={props.eyeCoords}
+                eyeShape={props.eyeShape}
                 cornerShape={cornerShape}
                 bezier={props.bezier}
                 scleraRadius={props.scleraRadius}
             />
             <BlackFill
-                eyeCoords={props.eyeCoords}
+                eyeShape={props.eyeShape}
                 scleraRadius={props.scleraRadius}
                 height={props.height}
                 width={props.width}

--- a/src/components/eye/eyeParts/BlackFill.tsx
+++ b/src/components/eye/eyeParts/BlackFill.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import isEqual from 'react-fast-compare';
 
 interface IBlackFillProps {
-    eyeCoords: {
+    eyeShape: {
         leftX: number;
         rightX: number;
         middleY: number;
@@ -20,18 +20,18 @@ export const BlackFill = React.memo(
         return (
             <svg className="BlackFill">
                 <path
-                    d={`M 0 ${props.eyeCoords.middleY},
-                         L ${props.eyeCoords.leftX} ${props.eyeCoords.middleY},
-                         A ${props.scleraRadius} ${props.scleraRadius} 0 0 1 ${props.eyeCoords.rightX} ${props.eyeCoords.middleY}
-                         L ${props.width} ${props.eyeCoords.middleY},
+                    d={`M 0 ${props.eyeShape.middleY},
+                         L ${props.eyeShape.leftX} ${props.eyeShape.middleY},
+                         A ${props.scleraRadius} ${props.scleraRadius} 0 0 1 ${props.eyeShape.rightX} ${props.eyeShape.middleY}
+                         L ${props.width} ${props.eyeShape.middleY},
                          L ${props.width} 0
                          L 0 0`}
                 />
                 <path
-                    d={`M 0 ${props.eyeCoords.middleY},
-                         L ${props.eyeCoords.leftX} ${props.eyeCoords.middleY},
-                         A ${props.scleraRadius} ${props.scleraRadius} 0 0 0 ${props.eyeCoords.rightX} ${props.eyeCoords.middleY}
-                         L ${props.width} ${props.eyeCoords.middleY},
+                    d={`M 0 ${props.eyeShape.middleY},
+                         L ${props.eyeShape.leftX} ${props.eyeShape.middleY},
+                         A ${props.scleraRadius} ${props.scleraRadius} 0 0 0 ${props.eyeShape.rightX} ${props.eyeShape.middleY}
+                         L ${props.width} ${props.eyeShape.middleY},
                          L ${props.width} ${props.height}
                          L 0 ${props.height}`}
                 />

--- a/src/components/eye/eyeParts/Eyelids.tsx
+++ b/src/components/eye/eyeParts/Eyelids.tsx
@@ -3,7 +3,7 @@ import isEqual from 'react-fast-compare';
 
 interface IEyelidsProps {
     transitionStyle: { transition: string };
-    eyeCoords: {
+    eyeShape: {
         leftX: number;
         rightX: number;
         middleY: number;
@@ -34,31 +34,31 @@ export const Eyelids = React.memo(
                     filter="url(#shadowTop)"
                     d={
                         // upper eyelid
-                        `M ${props.eyeCoords.leftX} ${props.eyeCoords.middleY},
+                        `M ${props.eyeShape.leftX} ${props.eyeShape.middleY},
                          A ${props.scleraRadius} ${props.scleraRadius} 0 0 1 ${
-                            props.eyeCoords.rightX
-                        } ${props.eyeCoords.middleY}
-                         C ${props.eyeCoords.rightX -
+                            props.eyeShape.rightX
+                        } ${props.eyeShape.middleY}
+                         C ${props.eyeShape.rightX -
                              props.cornerShape.rightTop *
                                  props.bezier.scaledXcontrolOffset} ${props
-                            .eyeCoords.middleY -
+                            .eyeShape.middleY -
                             props.bezier.scaledYcontrolOffset},
-                         ${props.eyeCoords.middleX +
+                         ${props.eyeShape.middleX +
                              props.bezier.controlOffset} ${
-                            props.eyeCoords.topEyelidY
-                        }, ${props.eyeCoords.middleX} ${
-                            props.eyeCoords.topEyelidY
+                            props.eyeShape.topEyelidY
+                        }, ${props.eyeShape.middleX} ${
+                            props.eyeShape.topEyelidY
                         }
-                         C ${props.eyeCoords.middleX -
+                         C ${props.eyeShape.middleX -
                              props.bezier.controlOffset} ${
-                            props.eyeCoords.topEyelidY
-                        }, ${props.eyeCoords.leftX +
+                            props.eyeShape.topEyelidY
+                        }, ${props.eyeShape.leftX +
                             props.cornerShape.leftTop *
                                 props.bezier.scaledXcontrolOffset} ${props
-                            .eyeCoords.middleY -
+                            .eyeShape.middleY -
                             props.bezier.scaledYcontrolOffset}, ${
-                            props.eyeCoords.leftX
-                        } ${props.eyeCoords.middleY}`
+                            props.eyeShape.leftX
+                        } ${props.eyeShape.middleY}`
                     }
                 />
                 <path
@@ -66,31 +66,31 @@ export const Eyelids = React.memo(
                     filter="url(#shadowBottom)"
                     d={
                         // lower eyelid
-                        `M ${props.eyeCoords.leftX} ${props.eyeCoords.middleY},
+                        `M ${props.eyeShape.leftX} ${props.eyeShape.middleY},
                          A ${props.scleraRadius} ${props.scleraRadius} 0 0 0 ${
-                            props.eyeCoords.rightX
-                        } ${props.eyeCoords.middleY}
-                         C ${props.eyeCoords.rightX -
+                            props.eyeShape.rightX
+                        } ${props.eyeShape.middleY}
+                         C ${props.eyeShape.rightX -
                              props.cornerShape.rightBottom *
                                  props.bezier.scaledXcontrolOffset} ${props
-                            .eyeCoords.middleY +
+                            .eyeShape.middleY +
                             props.bezier.scaledYcontrolOffset},
-                         ${props.eyeCoords.middleX +
+                         ${props.eyeShape.middleX +
                              props.bezier.controlOffset} ${
-                            props.eyeCoords.bottomEyelidY
-                        }, ${props.eyeCoords.middleX} ${
-                            props.eyeCoords.bottomEyelidY
+                            props.eyeShape.bottomEyelidY
+                        }, ${props.eyeShape.middleX} ${
+                            props.eyeShape.bottomEyelidY
                         }
-                         C ${props.eyeCoords.middleX -
+                         C ${props.eyeShape.middleX -
                              props.bezier.controlOffset} ${
-                            props.eyeCoords.bottomEyelidY
-                        }, ${props.eyeCoords.leftX +
+                            props.eyeShape.bottomEyelidY
+                        }, ${props.eyeShape.leftX +
                             props.cornerShape.leftBottom *
                                 props.bezier.scaledXcontrolOffset} ${props
-                            .eyeCoords.middleY +
+                            .eyeShape.middleY +
                             props.bezier.scaledYcontrolOffset}, ${
-                            props.eyeCoords.leftX
-                        } ${props.eyeCoords.middleY}`
+                            props.eyeShape.leftX
+                        } ${props.eyeShape.middleY}`
                     }
                 />
             </svg>

--- a/src/store/actions/detections/actions.ts
+++ b/src/store/actions/detections/actions.ts
@@ -7,6 +7,7 @@ import {
     minTargetInterval,
 } from '../../../AppConstants';
 import { Detections, IDetection } from '../../../models/objectDetection';
+import calculateTargetPos from '../../../utils/objectTracking/calculateFocus';
 import { Animation, animationMapping } from '../../../utils/pose/animations';
 import { getPose } from '../../../utils/pose/poseDetection';
 import { IColour, ICoords } from '../../../utils/types';
@@ -95,13 +96,7 @@ export function handleDetection(document: Document) {
                 left = reshapeDetections(leftDetections);
             }
 
-            dispatch(
-                setDetectionsAndMaybeSwapTarget(
-                    left,
-                    getTargets(state),
-                    getColour(state),
-                ),
-            );
+            dispatch(setDetectionsAndMaybeSwapTarget(left));
 
             // The way we get target will change once #273 is implemented
             // For now I compare selection bounding box to existing detections and select a target from there
@@ -127,11 +122,7 @@ export function setIdleTarget(coords: ICoords): ISetIdleTargetAction {
     };
 }
 
-export function setDetectionsAndMaybeSwapTarget(
-    detections: Detections,
-    previousTarget: ICoords,
-    previousColour: IColour,
-) {
+export function setDetectionsAndMaybeSwapTarget(detections: Detections) {
     return (
         dispatch: ThunkDispatch<IRootStore, void, Action>,
         getState: () => IRootStore,
@@ -139,8 +130,15 @@ export function setDetectionsAndMaybeSwapTarget(
         const state = getState();
         const now = new Date().getTime();
         if (now < state.detectionStore.nextSelectionSwapTime) {
-            dispatch(setDetections(detections, previousTarget, previousColour));
+            dispatch(
+                setDetections(detections, getTargets(state), getColour(state)),
+            );
         } else {
+            const previousSelection = getSelections(state);
+            if (previousSelection && detections.length > 1) {
+                removeClosestToSelection(detections, previousSelection);
+            }
+
             const selectionIndex = Math.floor(
                 Math.random() * (detections.length - 1),
             );
@@ -158,6 +156,27 @@ export function setDetectionsAndMaybeSwapTarget(
             );
         }
     };
+}
+
+function removeClosestToSelection(
+    detections: IDetection[],
+    selection: IDetection,
+) {
+    const selectionTargetPos = calculateTargetPos(selection.bbox);
+    let closestIndex = 0;
+    let closestDistance = Number.MAX_SAFE_INTEGER;
+    detections.forEach((detection, index) => {
+        const targetPos = calculateTargetPos(detection.bbox);
+        const distance = Math.hypot(
+            targetPos.x - selectionTargetPos.x,
+            targetPos.y - selectionTargetPos.y,
+        );
+        if (distance < closestDistance) {
+            closestIndex = index;
+            closestDistance = distance;
+        }
+    });
+    detections.splice(closestIndex, 1);
 }
 
 export function setDetections(


### PR DESCRIPTION
- eyes now avoid swapping to target closest to the previous tracked target
- removed `previousTarget` and `previousColour` arguments for `setDetectionsAndMaybeSwapTarget`. This action is a thunk, so can access the state anyway.