### PR TITLE
feature/328 improved pose drawing

### DIFF
--- a/src/components/configMenu/menuItems/CanvasMenuItem.tsx
+++ b/src/components/configMenu/menuItems/CanvasMenuItem.tsx
@@ -106,6 +106,7 @@ export class CanvasMenuItem extends React.Component<CanvasMenuItemProps> {
     ) {
         if (this.props.selection && detections && canvasCtx) {
             detections
+                .filter(detection => detection.info.keypoints !== focusedPose)
                 .map(detection => detection.info.keypoints)
                 .forEach(keypointSet => {
                     drawPose(keypointSet, canvasCtx, nonChosenTargetColour);


### PR DESCRIPTION
- Partially solved the issue of drawing green poses over red poses
- Part of this issue is simply that posenet sometimes mistakes one person for several people standing in front of eachother - we should try to solve this by fine-tuning posenet configuration