### PR TITLE
fixed config bug by setting multiplier to 1 when model changes

### DIFF
--- a/src/store/actions/config/actions.ts
+++ b/src/store/actions/config/actions.ts
@@ -32,6 +32,7 @@ export function updateConfigAction(
                     dispatch(
                         setConfigAction(ConfigSetAction.MODEL, {
                             outputStride: '16',
+                            multiplier: '1',
                         }),
                     );
                 }


### PR DESCRIPTION
This PR addresses #335 regarding the application crashing for invalid config menus when posenet is selected and the multiplier is not set to 1.

This has been fixed by setting the multiplier to 1 every time the model is changed.