### PR TITLE
feature/342 hide config menu with no camera

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,7 @@ export class App extends React.Component<AppProps, IAppState> {
                                 height={this.state.height}
                                 environment={this.props.environment}
                             />
+                            <ConfigMenuElement window={this.props.environment.window} />
                         </div>
                     )
                 ) : (
@@ -102,8 +103,6 @@ export class App extends React.Component<AppProps, IAppState> {
                         No webcam connected. Please connect a webcam.
                     </div>
                 )}
-
-                <ConfigMenuElement window={this.props.environment.window} />
             </div>
         );
     }


### PR DESCRIPTION
config menu is now only displayed when a camera is plugged in and the model is loaded