### PR TITLE
test/371 eye parts

### DIFF
--- a/src/__tests__/components/eyeParts/BlackFill.test.tsx
+++ b/src/__tests__/components/eyeParts/BlackFill.test.tsx
@@ -1,0 +1,24 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+    BlackFill,
+    IBlackFillProps,
+} from '../../../components/eye/eyeParts/BlackFill';
+
+let props: IBlackFillProps;
+
+describe('Blackfill', () => {
+    beforeEach(() => {
+        props = {
+            leftX: 20,
+            scleraRadius: 300,
+            width: 1920,
+            height: 1080,
+        };
+    });
+
+    it('should render correctly', () => {
+        const wrapper = shallow(<BlackFill {...props} />).debug();
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/__tests__/components/eyeParts/Eyelids.test.tsx
+++ b/src/__tests__/components/eyeParts/Eyelids.test.tsx
@@ -1,0 +1,41 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+    Eyelids,
+    IEyelidsProps,
+} from '../../../components/eye/eyeParts/Eyelids';
+
+let props: IEyelidsProps;
+
+describe('Blackfill', () => {
+    beforeEach(() => {
+        props = {
+            transitionStyle: { transition: '' },
+            eyeCoords: {
+                leftX: 0,
+                rightX: 0,
+                middleY: 0,
+                middleX: 0,
+                topEyelidY: 0,
+                bottomEyelidY: 0,
+            },
+            cornerShape: {
+                leftTop: 0,
+                rightTop: 0,
+                leftBottom: 0,
+                rightBottom: 0,
+            },
+            scleraRadius: 300,
+            bezier: {
+                controlOffset: 20,
+                scaledXcontrolOffset: 20,
+                scaledYcontrolOffset: 30,
+            },
+        };
+    });
+
+    it('should render correctly', () => {
+        const wrapper = shallow(<Eyelids {...props} />).debug();
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/__tests__/components/eyeParts/Eyelids.test.tsx
+++ b/src/__tests__/components/eyeParts/Eyelids.test.tsx
@@ -7,11 +7,11 @@ import {
 
 let props: IEyelidsProps;
 
-describe('Blackfill', () => {
+describe('Eyelids', () => {
     beforeEach(() => {
         props = {
             transitionStyle: { transition: '' },
-            eyeCoords: {
+            eyeShape: {
                 leftX: 0,
                 rightX: 0,
                 middleY: 0,

--- a/src/__tests__/components/eyeParts/InnerEye.test.tsx
+++ b/src/__tests__/components/eyeParts/InnerEye.test.tsx
@@ -1,0 +1,47 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import {
+    InnerEye,
+    InnerEyeProps,
+} from '../../../components/eye/eyeParts/InnerEye';
+
+let props: InnerEyeProps;
+
+const data = new Uint8ClampedArray(400);
+
+for (let i = 0; i < 400; i += 4) {
+    data[i + 0] = 190; // R value
+    data[i + 1] = 0; // G value
+    data[i + 2] = 210; // B value
+    data[i + 3] = 255; // A value
+}
+
+const imageData = { data, width: 10, height: 10 };
+
+describe('InnerEye', () => {
+    beforeEach(() => {
+        props = {
+            irisRadius: 200,
+            dilatedCoefficient: 1,
+            innerX: 0,
+            innerY: 0,
+            irisColor: 'blue',
+            fps: 30,
+            height: 800,
+            width: 1000,
+            pupilColor: 'black',
+            pupilRadius: 100,
+            scleraRadius: 500,
+            reflectionOpacity: 0.5,
+            showReflection: true,
+            target: { x: 0, y: 0 },
+            innerPath: '',
+            image: undefined,
+        };
+    });
+
+    it('should render correctly', () => {
+        const wrapper = shallow(<InnerEye {...props} />).debug();
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/__tests__/components/eyeParts/InnerEye.test.tsx
+++ b/src/__tests__/components/eyeParts/InnerEye.test.tsx
@@ -7,17 +7,6 @@ import {
 
 let props: InnerEyeProps;
 
-const data = new Uint8ClampedArray(400);
-
-for (let i = 0; i < 400; i += 4) {
-    data[i + 0] = 190; // R value
-    data[i + 1] = 0; // G value
-    data[i + 2] = 210; // B value
-    data[i + 3] = 255; // A value
-}
-
-const imageData = { data, width: 10, height: 10 };
-
 describe('InnerEye', () => {
     beforeEach(() => {
         props = {

--- a/src/__tests__/components/eyeParts/InnerEye.test.tsx
+++ b/src/__tests__/components/eyeParts/InnerEye.test.tsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import {
     InnerEye,
@@ -6,6 +6,16 @@ import {
 } from '../../../components/eye/eyeParts/InnerEye';
 
 let props: InnerEyeProps;
+const data = new Uint8ClampedArray(400);
+
+for (let i = 0; i < 400; i += 4) {
+    data[i + 0] = 190; // R value
+    data[i + 1] = 0; // G value
+    data[i + 2] = 210; // B value
+    data[i + 3] = 255; // A value
+}
+
+const imageData = { data, width: 10, height: 10 };
 
 describe('InnerEye', () => {
     beforeEach(() => {
@@ -21,11 +31,9 @@ describe('InnerEye', () => {
             pupilColor: 'black',
             pupilRadius: 100,
             scleraRadius: 500,
-            reflectionOpacity: 0.5,
-            showReflection: true,
-            target: { x: 0, y: 0 },
+            reflection: imageData,
             innerPath: '',
-            image: undefined,
+            irisAdjustment: { scale: 0, angle: 0 },
         };
     });
 

--- a/src/__tests__/components/eyeParts/Sclera.test.tsx
+++ b/src/__tests__/components/eyeParts/Sclera.test.tsx
@@ -1,0 +1,20 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { IScleraProps, Sclera } from '../../../components/eye/eyeParts/Sclera';
+
+let props: IScleraProps;
+
+describe('Sclera', () => {
+    beforeEach(() => {
+        props = {
+            radius: 100,
+            width: 1000,
+            height: 800,
+        };
+    });
+
+    it('should render correctly', () => {
+        const wrapper = shallow(<Sclera {...props} />).debug();
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/__tests__/components/eyeParts/__snapshots__/BlackFill.test.tsx.snap
+++ b/src/__tests__/components/eyeParts/__snapshots__/BlackFill.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Blackfill should render correctly 1`] = `
+"<svg className=\\"BlackFill\\">
+  <path d=\\"M 0 540,\\\\n                         H 20,\\\\n                         A 300 300 0 1 1 20 541\\\\n                         v -1\\\\n                         H 0\\\\n                         V 0\\\\n                         H 1920\\\\n                         V 1080\\\\n                         H 0\\\\n                         Z\\" />
+</svg>"
+`;

--- a/src/__tests__/components/eyeParts/__snapshots__/Eyelids.test.tsx.snap
+++ b/src/__tests__/components/eyeParts/__snapshots__/Eyelids.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Blackfill should render correctly 1`] = `
+"<svg className=\\"Eyelids\\">
+  <path style={{...}} filter=\\"url(#shadowTop)\\" d=\\"M 0 0,\\\\n                         A 300 300 0 0 1 0 0\\\\n                         C 0 -30,\\\\n                         20 0, 0 0\\\\n                         C -20 0, 0 -30, 0 0\\" />
+  <path style={{...}} filter=\\"url(#shadowBottom)\\" d=\\"M 0 0,\\\\n                         A 300 300 0 0 0 0 0\\\\n                         C 0 30,\\\\n                         20 0, 0 0\\\\n                         C -20 0, 0 30, 0 0\\" />
+</svg>"
+`;

--- a/src/__tests__/components/eyeParts/__snapshots__/Eyelids.test.tsx.snap
+++ b/src/__tests__/components/eyeParts/__snapshots__/Eyelids.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Blackfill should render correctly 1`] = `
+exports[`Eyelids should render correctly 1`] = `
 "<svg className=\\"Eyelids\\">
   <path style={{...}} filter=\\"url(#shadowTop)\\" d=\\"M 0 0,\\\\n                         A 300 300 0 0 1 0 0\\\\n                         C 0 -30,\\\\n                         20 0, 0 0\\\\n                         C -20 0, 0 -30, 0 0\\" />
   <path style={{...}} filter=\\"url(#shadowBottom)\\" d=\\"M 0 0,\\\\n                         A 300 300 0 0 0 0 0\\\\n                         C 0 30,\\\\n                         20 0, 0 0\\\\n                         C -20 0, 0 30, 0 0\\" />

--- a/src/__tests__/components/eyeParts/__snapshots__/InnerEye.test.tsx.snap
+++ b/src/__tests__/components/eyeParts/__snapshots__/InnerEye.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InnerEye should render correctly 1`] = `
-"<g className=\\"inner\\" style={{...}} transform=\\"\\\\n                    rotate(38.65980825409008)\\\\n                    scale(0.6986765064737483, 1)\\\\n                    rotate(-38.65980825409008)\\\\n                    translate(0,0)\\\\n                \\">
+"<g className=\\"inner\\" style={{...}} transform=\\"\\\\n                    rotate(0)\\\\n                    scale(0, 1)\\\\n                    rotate(0)\\\\n                    translate(0,0)\\\\n                \\">
   <circle className=\\"iris\\" r={200} fill=\\"url(#irisGradient)\\" />
   <path className=\\"irisStyling\\" d=\\"\\" fill=\\"#0000cc\\" />
   <g className=\\"pupil\\" style={{...}} transform=\\"scale(1)\\">
@@ -10,7 +10,7 @@ exports[`InnerEye should render correctly 1`] = `
     </foreignObject>
     <circle className=\\"pupil\\" r={100} fill=\\"url(#pupilGradient)\\" stroke=\\"black\\" strokeWidth=\\"2\\" />
   </g>
-  <ellipse className=\\"innerReflection\\" rx={37.5} ry={75} fill=\\"url(#shineGradient)\\" transform=\\"skewX(30) translate(100,-50)\\" />
-  <ellipse className=\\"outerReflection\\" rx={50} ry={100} fill=\\"url(#shineGradient)\\" transform=\\"skewX(30) translate(200,-110.00000000000001)\\" />
+  <ellipse className=\\"innerShine\\" rx={37.5} ry={75} fill=\\"url(#shineGradient)\\" transform=\\"skewX(30) translate(100,-50)\\" />
+  <ellipse className=\\"outerShine\\" rx={50} ry={100} fill=\\"url(#shineGradient)\\" transform=\\"skewX(30) translate(200,-110.00000000000001)\\" />
 </g>"
 `;

--- a/src/__tests__/components/eyeParts/__snapshots__/InnerEye.test.tsx.snap
+++ b/src/__tests__/components/eyeParts/__snapshots__/InnerEye.test.tsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InnerEye should render correctly 1`] = `
+"<g className=\\"inner\\" style={{...}} transform=\\"\\\\n                    rotate(38.65980825409008)\\\\n                    scale(0.6986765064737483, 1)\\\\n                    rotate(-38.65980825409008)\\\\n                    translate(0,0)\\\\n                \\">
+  <circle className=\\"iris\\" r={200} fill=\\"url(#irisGradient)\\" />
+  <path className=\\"irisStyling\\" d=\\"\\" fill=\\"#0000cc\\" />
+  <g className=\\"pupil\\" style={{...}} transform=\\"scale(1)\\">
+    <foreignObject width={200} height={200} x={-100} y={-100}>
+      <canvas width={200} height={200} />
+    </foreignObject>
+    <circle className=\\"pupil\\" r={100} fill=\\"url(#pupilGradient)\\" stroke=\\"black\\" strokeWidth=\\"2\\" />
+  </g>
+  <ellipse className=\\"innerReflection\\" rx={37.5} ry={75} fill=\\"url(#shineGradient)\\" transform=\\"skewX(30) translate(100,-50)\\" />
+  <ellipse className=\\"outerReflection\\" rx={50} ry={100} fill=\\"url(#shineGradient)\\" transform=\\"skewX(30) translate(200,-110.00000000000001)\\" />
+</g>"
+`;

--- a/src/__tests__/components/eyeParts/__snapshots__/Sclera.test.tsx.snap
+++ b/src/__tests__/components/eyeParts/__snapshots__/Sclera.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sclera should render correctly 1`] = `"<circle className=\\"sclera\\" r={100} fill=\\"url(#scleraGradient)\\" cx={1000} cy={800} />"`;

--- a/src/components/eye/eyeParts/BlackFill.tsx
+++ b/src/components/eye/eyeParts/BlackFill.tsx
@@ -1,23 +1,21 @@
 import React from 'react';
-import isEqual from 'react-fast-compare';
 
-interface IBlackFillProps {
+export interface IBlackFillProps {
     leftX: number;
     scleraRadius: number;
     width: number;
     height: number;
 }
 
-export const BlackFill = React.memo(
-    (props: IBlackFillProps) => {
-        return (
-            <svg className="BlackFill">
-                <path
-                    d={`M 0 ${props.height / 2},
+export const BlackFill = React.memo((props: IBlackFillProps) => {
+    return (
+        <svg className="BlackFill">
+            <path
+                d={`M 0 ${props.height / 2},
                          H ${props.leftX},
                          A ${props.scleraRadius} ${props.scleraRadius} 0 1 1 ${
-                        props.leftX
-                    } ${props.height / 2 + 1}
+                    props.leftX
+                } ${props.height / 2 + 1}
                          v -1
                          H 0
                          V 0
@@ -25,9 +23,7 @@ export const BlackFill = React.memo(
                          V ${props.height}
                          H 0
                          Z`}
-                />
-            </svg>
-        );
-    },
-    (previous, next) => isEqual(previous, next),
-);
+            />
+        </svg>
+    );
+});

--- a/src/components/eye/eyeParts/Eyelids.tsx
+++ b/src/components/eye/eyeParts/Eyelids.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import isEqual from 'react-fast-compare';
 
 interface IEyelidsProps {
     transitionStyle: { transition: string };
@@ -25,76 +24,65 @@ interface IEyelidsProps {
     scleraRadius: number;
 }
 
-export const Eyelids = React.memo(
-    (props: IEyelidsProps) => {
-        return (
-            <svg className="Eyelids">
-                <path
-                    style={props.transitionStyle}
-                    filter="url(#shadowTop)"
-                    d={
-                        // upper eyelid
-                        `M ${props.eyeShape.leftX} ${props.eyeShape.middleY},
+export const Eyelids = React.memo((props: IEyelidsProps) => {
+    return (
+        <svg className="Eyelids">
+            <path
+                style={props.transitionStyle}
+                filter="url(#shadowTop)"
+                d={
+                    // upper eyelid
+                    `M ${props.eyeShape.leftX} ${props.eyeShape.middleY},
                          A ${props.scleraRadius} ${props.scleraRadius} 0 0 1 ${
-                            props.eyeShape.rightX
-                        } ${props.eyeShape.middleY}
+                        props.eyeShape.rightX
+                    } ${props.eyeShape.middleY}
                          C ${props.eyeShape.rightX -
                              props.cornerShape.rightTop *
                                  props.bezier.scaledXcontrolOffset} ${props
-                            .eyeShape.middleY -
-                            props.bezier.scaledYcontrolOffset},
+                        .eyeShape.middleY - props.bezier.scaledYcontrolOffset},
                          ${props.eyeShape.middleX +
                              props.bezier.controlOffset} ${
-                            props.eyeShape.topEyelidY
-                        }, ${props.eyeShape.middleX} ${
-                            props.eyeShape.topEyelidY
-                        }
+                        props.eyeShape.topEyelidY
+                    }, ${props.eyeShape.middleX} ${props.eyeShape.topEyelidY}
                          C ${props.eyeShape.middleX -
                              props.bezier.controlOffset} ${
-                            props.eyeShape.topEyelidY
-                        }, ${props.eyeShape.leftX +
-                            props.cornerShape.leftTop *
-                                props.bezier.scaledXcontrolOffset} ${props
-                            .eyeShape.middleY -
-                            props.bezier.scaledYcontrolOffset}, ${
-                            props.eyeShape.leftX
-                        } ${props.eyeShape.middleY}`
-                    }
-                />
-                <path
-                    style={props.transitionStyle}
-                    filter="url(#shadowBottom)"
-                    d={
-                        // lower eyelid
-                        `M ${props.eyeShape.leftX} ${props.eyeShape.middleY},
+                        props.eyeShape.topEyelidY
+                    }, ${props.eyeShape.leftX +
+                        props.cornerShape.leftTop *
+                            props.bezier.scaledXcontrolOffset} ${props.eyeShape
+                        .middleY - props.bezier.scaledYcontrolOffset}, ${
+                        props.eyeShape.leftX
+                    } ${props.eyeShape.middleY}`
+                }
+            />
+            <path
+                style={props.transitionStyle}
+                filter="url(#shadowBottom)"
+                d={
+                    // lower eyelid
+                    `M ${props.eyeShape.leftX} ${props.eyeShape.middleY},
                          A ${props.scleraRadius} ${props.scleraRadius} 0 0 0 ${
-                            props.eyeShape.rightX
-                        } ${props.eyeShape.middleY}
+                        props.eyeShape.rightX
+                    } ${props.eyeShape.middleY}
                          C ${props.eyeShape.rightX -
                              props.cornerShape.rightBottom *
                                  props.bezier.scaledXcontrolOffset} ${props
-                            .eyeShape.middleY +
-                            props.bezier.scaledYcontrolOffset},
+                        .eyeShape.middleY + props.bezier.scaledYcontrolOffset},
                          ${props.eyeShape.middleX +
                              props.bezier.controlOffset} ${
-                            props.eyeShape.bottomEyelidY
-                        }, ${props.eyeShape.middleX} ${
-                            props.eyeShape.bottomEyelidY
-                        }
+                        props.eyeShape.bottomEyelidY
+                    }, ${props.eyeShape.middleX} ${props.eyeShape.bottomEyelidY}
                          C ${props.eyeShape.middleX -
                              props.bezier.controlOffset} ${
-                            props.eyeShape.bottomEyelidY
-                        }, ${props.eyeShape.leftX +
-                            props.cornerShape.leftBottom *
-                                props.bezier.scaledXcontrolOffset} ${props
-                            .eyeShape.middleY +
-                            props.bezier.scaledYcontrolOffset}, ${
-                            props.eyeShape.leftX
-                        } ${props.eyeShape.middleY}`
-                    }
-                />
-            </svg>
-        );
-    },
-    (previous, next) => isEqual(previous, next),
-);
+                        props.eyeShape.bottomEyelidY
+                    }, ${props.eyeShape.leftX +
+                        props.cornerShape.leftBottom *
+                            props.bezier.scaledXcontrolOffset} ${props.eyeShape
+                        .middleY + props.bezier.scaledYcontrolOffset}, ${
+                        props.eyeShape.leftX
+                    } ${props.eyeShape.middleY}`
+                }
+            />
+        </svg>
+    );
+});

--- a/src/components/eye/eyeParts/Eyelids.tsx
+++ b/src/components/eye/eyeParts/Eyelids.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface IEyelidsProps {
+export interface IEyelidsProps {
     transitionStyle: { transition: string };
     eyeShape: {
         leftX: number;

--- a/src/components/eye/eyeParts/InnerEye.tsx
+++ b/src/components/eye/eyeParts/InnerEye.tsx
@@ -27,101 +27,96 @@ interface IInnerEyeMapStateToProps {
 
 type InnerEyeProps = IInnerEyeProps & IInnerEyeMapStateToProps;
 
-export const InnerEye = React.memo(
-    (props: InnerEyeProps) => {
-        const period = 1000 / props.fps;
-        const transitionStyle = {
-            transition: `transform ${period}ms`, // cx and cy transitions based on FPS
-        };
-        const canvasRef: React.RefObject<HTMLCanvasElement> = useRef(null);
+export const InnerEye = React.memo((props: InnerEyeProps) => {
+    const period = 1000 / props.fps;
+    const transitionStyle = {
+        transition: `transform ${period}ms`, // cx and cy transitions based on FPS
+    };
+    const canvasRef: React.RefObject<HTMLCanvasElement> = useRef(null);
 
-        useEffect(() => {
-            if (canvasRef && props.reflection) {
-                const canvas = canvasRef.current;
-                if (canvas) {
-                    const ctx = canvas.getContext('2d');
-                    if (ctx) {
-                        ctx.putImageData(props.reflection, 0, 0);
-                    }
+    useEffect(() => {
+        if (canvasRef && props.reflection) {
+            const canvas = canvasRef.current;
+            if (canvas) {
+                const ctx = canvas.getContext('2d');
+                if (ctx) {
+                    ctx.putImageData(props.reflection, 0, 0);
                 }
             }
-        }, [props.reflection]);
+        }
+    }, [props.reflection]);
 
-        return (
-            <g
-                className="inner"
-                style={transitionStyle}
-                transform={`
+    return (
+        <g
+            className="inner"
+            style={transitionStyle}
+            transform={`
                     rotate(${props.irisAdjustment.angle})
                     scale(${props.irisAdjustment.scale}, 1)
                     rotate(${-props.irisAdjustment.angle})
                     translate(${props.innerX},${props.innerY})
                 `}
+        >
+            <circle
+                className={'iris'}
+                r={props.irisRadius}
+                fill={'url(#irisGradient)'}
+            />
+            <path
+                className="irisStyling"
+                d={props.innerPath}
+                fill={tinycolor(props.irisColor)
+                    .darken(10)
+                    .toHexString()}
+            />
+            <g
+                className="pupil"
+                style={transitionStyle}
+                transform={`scale(${props.dilatedCoefficient})`}
             >
-                <circle
-                    className={'iris'}
-                    r={props.irisRadius}
-                    fill={'url(#irisGradient)'}
-                />
-                <path
-                    className="irisStyling"
-                    d={props.innerPath}
-                    fill={tinycolor(props.irisColor)
-                        .darken(10)
-                        .toHexString()}
-                />
-                <g
-                    className="pupil"
-                    style={transitionStyle}
-                    transform={`scale(${props.dilatedCoefficient})`}
+                <foreignObject
+                    width={props.pupilRadius * 2}
+                    height={props.pupilRadius * 2}
+                    x={-props.pupilRadius}
+                    y={-props.pupilRadius}
                 >
-                    <foreignObject
-                        width={props.pupilRadius * 2}
-                        height={props.pupilRadius * 2}
-                        x={-props.pupilRadius}
-                        y={-props.pupilRadius}
-                    >
-                        {props.reflection && (
-                            <canvas
-                                ref={canvasRef}
-                                width={props.pupilRadius * 2}
-                                height={props.pupilRadius * 2}
-                            />
-                        )}
-                    </foreignObject>
-                    <circle
-                        className={'pupil'}
-                        r={props.pupilRadius}
-                        fill={
-                            props.reflection ? 'url(#pupilGradient)' : 'black'
-                        }
-                        stroke={'black'}
-                        strokeWidth={'2'}
-                    />
-                </g>
-                <ellipse
-                    className={'innerShine'}
-                    rx={props.pupilRadius * 0.375}
-                    ry={props.pupilRadius * 0.75}
-                    fill={'url(#shineGradient)'}
-                    transform={`skewX(30) translate(${
-                        props.pupilRadius
-                    },${-props.pupilRadius * 0.5})`}
-                />
-                <ellipse
-                    className={'outerShine'}
-                    rx={props.pupilRadius * 0.5}
-                    ry={props.pupilRadius}
-                    fill={'url(#shineGradient)'}
-                    transform={`skewX(30) translate(${
-                        props.irisRadius
-                    },${-props.irisRadius * 0.55})`}
+                    {props.reflection && (
+                        <canvas
+                            ref={canvasRef}
+                            width={props.pupilRadius * 2}
+                            height={props.pupilRadius * 2}
+                        />
+                    )}
+                </foreignObject>
+                <circle
+                    className={'pupil'}
+                    r={props.pupilRadius}
+                    fill={props.reflection ? 'url(#pupilGradient)' : 'black'}
+                    stroke={'black'}
+                    strokeWidth={'2'}
                 />
             </g>
-        );
-    },
-    (previous, next) => isEqual(previous, next),
-);
+            <ellipse
+                className={'innerShine'}
+                rx={props.pupilRadius * 0.375}
+                ry={props.pupilRadius * 0.75}
+                fill={'url(#shineGradient)'}
+                transform={`skewX(30) translate(${
+                    props.pupilRadius
+                },${-props.pupilRadius * 0.5})`}
+            />
+            <ellipse
+                className={'outerShine'}
+                rx={props.pupilRadius * 0.5}
+                ry={props.pupilRadius}
+                fill={'url(#shineGradient)'}
+                transform={`skewX(30) translate(${
+                    props.irisRadius
+                },${-props.irisRadius * 0.55})`}
+            />
+        </g>
+    );
+});
 
 const mapStateToProps = (state: IRootStore): IInnerEyeMapStateToProps => ({
     fps: state.configStore.fps,

--- a/src/components/eye/eyeParts/InnerEye.tsx
+++ b/src/components/eye/eyeParts/InnerEye.tsx
@@ -24,7 +24,7 @@ interface IInnerEyeMapStateToProps {
     fps: number;
 }
 
-type InnerEyeProps = IInnerEyeProps & IInnerEyeMapStateToProps;
+export type InnerEyeProps = IInnerEyeProps & IInnerEyeMapStateToProps;
 
 export const InnerEye = React.memo((props: InnerEyeProps) => {
     const period = 1000 / props.fps;

--- a/src/components/eye/eyeParts/InnerEye.tsx
+++ b/src/components/eye/eyeParts/InnerEye.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react';
-import isEqual from 'react-fast-compare';
 import { connect } from 'react-redux';
 import tinycolor from 'tinycolor2';
 import { IRootStore } from '../../../store/reducers/rootReducer';

--- a/src/components/eye/eyeParts/Sclera.tsx
+++ b/src/components/eye/eyeParts/Sclera.tsx
@@ -1,23 +1,19 @@
 import React from 'react';
-import isEqual from 'react-fast-compare';
 
-interface IScleraProps {
+export interface IScleraProps {
     radius: number;
     width: number;
     height: number;
 }
 
-export const Sclera = React.memo(
-    (props: IScleraProps) => {
-        return (
-            <circle
-                className={'sclera'}
-                r={props.radius}
-                fill={'url(#scleraGradient)'}
-                cx={props.width}
-                cy={props.height}
-            />
-        );
-    },
-    (previous, next) => isEqual(previous, next),
-);
+export const Sclera = React.memo((props: IScleraProps) => {
+    return (
+        <circle
+            className={'sclera'}
+            r={props.radius}
+            fill={'url(#scleraGradient)'}
+            cx={props.width}
+            cy={props.height}
+        />
+    );
+});


### PR DESCRIPTION
 #371 wrote snapshot tests for the eye parts components: sclera, blackfill, eyelids and innerEye.
I also removed the isEqual comparison from the memoized components as those were unnecessary. This caused the prettier to reformat the whole files causing big changes in the following files:
- InnerEye.tsx
- Blackfill.tsx
- Sclera.tsx
- Eyelids.tsx
The only change in those files is the removal of the comparison of previous and next props by using ```isEqual``` from react-fast-compare. Additionally, I updated the type of ```innerPath``` prop in the InnerEye from ```any``` to ```string```