### PR TITLE
Feature/386 no person reflection

### DIFF
--- a/src/components/eye/EyeController.tsx
+++ b/src/components/eye/EyeController.tsx
@@ -144,21 +144,17 @@ export const EyeController = React.memo(
         }, [animation, updateAnimation, environment]);
 
         useEffect(() => {
-            if (
-                props.config.toggleReflection &&
-                props.selection &&
-                props.image
-            ) {
+            if (props.config.toggleReflection && props.image) {
                 reflectionRef.current = getReflection(
                     pupilRadius,
-                    props.selection.bbox,
+                    props.target,
                     props.image,
                 );
             } else {
                 reflectionRef.current = undefined;
             }
         }, [
-            props.selection,
+            props.target,
             props.image,
             props.config.toggleReflection,
             pupilRadius,

--- a/src/components/eye/utils/ReflectionUtils.ts
+++ b/src/components/eye/utils/ReflectionUtils.ts
@@ -45,25 +45,22 @@ function fisheye(
     const result = new Uint8ClampedArray(pixels.length);
 
     for (let currRow = 0; currRow < height; currRow++) {
-        const normalisedY = (2 * currRow) / height - 1; // a
-        const normalYSquared = normalisedY * normalisedY; // a^2
+        const normalisedY = (2 * currRow) / height - 1;
 
         for (let currColumn = 0; currColumn < width; currColumn++) {
-            const normalisedX = (2 * currColumn) / width - 1; // b
-            const normalXSquared = normalisedX * normalisedX; // b^2
-
-            const normalisedRadius = Math.sqrt(normalXSquared + normalYSquared); // c=sqrt(a^2 + b^2)
+            const normalisedX = (2 * currColumn) / width - 1;
+            const normalisedRadius = Math.hypot(normalisedX, normalisedY);
 
             // For any point in the circle
-            if (0.0 <= normalisedRadius && normalisedRadius <= 1.0) {
+            if (0 <= normalisedRadius && normalisedRadius <= 1) {
                 // The closer to the center it is, the larger the value
                 let radiusScaling = Math.sqrt(
-                    1.0 - normalisedRadius * normalisedRadius,
+                    1 - Math.pow(normalisedRadius, 2),
                 );
-                radiusScaling =
-                    (normalisedRadius + (1.0 - radiusScaling)) / 2.0;
                 // Exponential curve between 0 and 1, ie pixels closer to the center have a much lower scaling value
+                radiusScaling = (normalisedRadius + (1 - radiusScaling)) / 2;
 
+                // Adjusts the intensity of the fisheye
                 radiusScaling =
                     radiusScaling * fisheyeConsts.intensity +
                     normalisedRadius * (1 - fisheyeConsts.intensity);

--- a/src/components/eye/utils/ReflectionUtils.ts
+++ b/src/components/eye/utils/ReflectionUtils.ts
@@ -18,7 +18,6 @@ export function getReflection(
     ctx.clip();
     const crop = getCrop(target, image);
     ctx.scale(-1, 1);
-    ctx.filter = 'blur(1px)';
     const diameter = radius * 2;
     ctx.drawImage(
         image,
@@ -45,10 +44,10 @@ function fisheye(
     const result = new Uint8ClampedArray(pixels.length);
 
     for (let currRow = 0; currRow < height; currRow++) {
-        const normalisedY = (2 * currRow) / height - 1;
+        const normalisedY = normalise(currRow, height);
 
         for (let currColumn = 0; currColumn < width; currColumn++) {
-            const normalisedX = (2 * currColumn) / width - 1;
+            const normalisedX = normalise(currColumn, width);
             const normalisedRadius = Math.hypot(normalisedX, normalisedY);
 
             // For any point in the circle
@@ -66,10 +65,10 @@ function fisheye(
                     normalisedRadius * (1 - fisheyeConsts.intensity);
 
                 const theta = Math.atan2(normalisedY, normalisedX); // angle to point from center of circle
-                const scaledNormalisedX = radiusScaling * Math.cos(theta);
-                const scaledNormalisedY = radiusScaling * Math.sin(theta);
-                const newX = Math.floor(((scaledNormalisedX + 1) * width) / 2); // normalise x to size of circle
-                const newY = Math.floor(((scaledNormalisedY + 1) * height) / 2); // normalise y to size of circle
+                const xScale = radiusScaling * Math.cos(theta);
+                const yScale = radiusScaling * Math.sin(theta);
+                const newX = Math.floor(normalise(xScale, 1, -1, width, 0));
+                const newY = Math.floor(normalise(yScale, 1, -1, height, 0));
                 const srcpos = newY * width + newX; // New pixel position in array
                 if (srcpos >= 0 && srcpos < width * height) {
                     for (let i = 0; i < 4; i++) {

--- a/src/components/eye/utils/ReflectionUtils.ts
+++ b/src/components/eye/utils/ReflectionUtils.ts
@@ -4,7 +4,7 @@ import { ICoords } from '../../../utils/types';
 
 export function getReflection(
     radius: number,
-    selection: ICoords,
+    target: ICoords,
     image: HTMLVideoElement,
 ) {
     const canvas = document.createElement('canvas');
@@ -16,7 +16,7 @@ export function getReflection(
     ctx.arc(radius, radius, radius, 0, Math.PI * 2, true);
     ctx.closePath();
     ctx.clip();
-    const crop = getCrop(selection, image);
+    const crop = getCrop(target, image);
     ctx.scale(-1, 1);
     ctx.filter = 'blur(1px)';
     const diameter = radius * 2;

--- a/src/components/eye/utils/ReflectionUtils.ts
+++ b/src/components/eye/utils/ReflectionUtils.ts
@@ -23,7 +23,7 @@ export function getReflection(
     ctx.drawImage(
         image,
         crop.sourceX,
-        crop.sourceX,
+        crop.sourceY,
         crop.sourceWidth,
         crop.sourceHeight,
         0,

--- a/src/store/selectors/detectionSelectors.ts
+++ b/src/store/selectors/detectionSelectors.ts
@@ -38,13 +38,13 @@ export const getSelections = createSelector(
 export const getTargets = createSelector(
     [getSelections, getVideo],
     (selections, video): ICoords => {
-        return selections === undefined || !video
-            ? centerPoint
-            : calculateNormalisedPos(
+        return selections && video
+            ? calculateNormalisedPos(
                   selections.bbox,
                   video!.width,
                   video!.height,
-              );
+              )
+            : centerPoint;
     },
 );
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -13,7 +13,6 @@ export function reshapeDetections(detections: Pose[]): IDetection[] {
             keypoints[partIds.leftEye],
             keypoints[partIds.rightEye],
         ]);
-        console.log(box);
         return {
             bbox: [
                 box.minX,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -13,6 +13,7 @@ export function reshapeDetections(detections: Pose[]): IDetection[] {
             keypoints[partIds.leftEye],
             keypoints[partIds.rightEye],
         ]);
+        console.log(box);
         return {
             bbox: [
                 box.minX,


### PR DESCRIPTION
This feature addresses issue #386 to re-implement reflection tracking based on the target passed as normalised ICoords instead of as based on the selection. 

This allows the reflection to continue working during animations and if no detections are present. 

The feature was implemented once before but was overwritten in a merge conflict. 