### PR TITLE
bug/433 show loading spinner until model is fully loaded

### DIFF
--- a/src/store/actions/detections/actions.ts
+++ b/src/store/actions/detections/actions.ts
@@ -49,6 +49,7 @@ export function restartDetection(document: Document) {
     ) => {
         const state = getState();
         clearInterval(state.detectionStore.detectionInterval);
+        dispatch(handleDetection(document));
         const id = setInterval(
             () => dispatch(handleDetection(document)),
             1000 / getFPS(state),


### PR DESCRIPTION
call first handle detection do inside the restart action before setting up the interval. This will cause the spinner to be shown until the model and all the required stuff is fully loaded #433