### PR TITLE
Refactor/434 EyeController remove unused props

### DIFF
--- a/src/__tests__/components/eyeParts/InnerEye.test.tsx
+++ b/src/__tests__/components/eyeParts/InnerEye.test.tsx
@@ -22,8 +22,7 @@ describe('InnerEye', () => {
         props = {
             irisRadius: 200,
             dilatedCoefficient: 1,
-            innerX: 0,
-            innerY: 0,
+            innerCenter: { x: 0, y: 0 },
             irisColor: 'blue',
             fps: 30,
             height: 800,
@@ -33,7 +32,7 @@ describe('InnerEye', () => {
             scleraRadius: 500,
             reflection: imageData,
             innerPath: '',
-            irisAdjustment: { scale: 0, angle: 0 },
+            skewTransform: '',
         };
     });
 

--- a/src/__tests__/components/eyeParts/__snapshots__/InnerEye.test.tsx.snap
+++ b/src/__tests__/components/eyeParts/__snapshots__/InnerEye.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InnerEye should render correctly 1`] = `
-"<g className=\\"inner\\" style={{...}} transform=\\"undefined translate(0,0)\\">
+"<g className=\\"inner\\" style={{...}} transform=\\" translate(0,0)\\">
   <circle className=\\"iris\\" r={200} fill=\\"url(#irisGradient)\\" />
   <path className=\\"irisStyling\\" d=\\"\\" fill=\\"#0000cc\\" />
   <g className=\\"pupil\\" style={{...}} transform=\\"scale(1)\\">

--- a/src/components/eye/Eye.tsx
+++ b/src/components/eye/Eye.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { EyeSide, transitionTimes } from '../../AppConstants';
+import { ICoords } from '../../utils/types';
 import './Eye.css';
 import { BlackFill } from './eyeParts/BlackFill';
 import { Eyelids } from './eyeParts/Eyelids';
 import InnerEye from './eyeParts/InnerEye';
 import { Sclera } from './eyeParts/Sclera';
-import { IIrisAdjustment } from './utils/VisualUtils';
 
 export interface IEyeProps {
     class: EyeSide;
@@ -16,8 +16,7 @@ export interface IEyeProps {
     irisRadius: number;
     pupilRadius: number;
     dilatedCoefficient: number;
-    innerX: number;
-    innerY: number;
+    innerCenter: ICoords;
     fps: number;
     bezier: {
         controlOffset: number;
@@ -33,7 +32,6 @@ export interface IEyeProps {
         bottomEyelidY: number;
     };
     reflection: ImageData | undefined;
-    irisAdjustment: IIrisAdjustment;
     innerPath: string;
     skewTransform: string;
     transformDuration?: number;

--- a/src/components/eye/EyeController.tsx
+++ b/src/components/eye/EyeController.tsx
@@ -35,8 +35,8 @@ interface IEyeControllerProps {
     height: number;
     environment: Window;
     dilation: number;
-    detected: boolean;
     openCoefficient: number;
+    detected: boolean;
 }
 
 interface IEyeControllerMapStateToProps {
@@ -67,11 +67,6 @@ export const EyeController = React.memo(
             props.width * eyeRadiiCoefficients.pupil,
         );
 
-        const irisAdjustmentRef = useRef({
-            scale: 1,
-            angle: 0,
-        });
-
         const reflectionRef = useRef<ImageData | undefined>(undefined);
 
         const target =
@@ -89,6 +84,7 @@ export const EyeController = React.memo(
         const displacement = Math.min(1, polarDistance) * maxDisplacement;
         const innerX = props.width / 4 + displacement * Math.cos(polarAngle);
         const innerY = props.height / 2 + displacement * Math.sin(polarAngle);
+        const innerCenter = { x: innerX, y: innerY };
 
         const calculatedEyesOpenCoefficient =
             props.animation.length > 0 &&
@@ -200,13 +196,11 @@ export const EyeController = React.memo(
                             irisRadius={irisRadius}
                             pupilRadius={pupilRadius}
                             dilatedCoefficient={dilatedCoefficient}
-                            innerX={innerX}
-                            innerY={innerY}
+                            innerCenter={innerCenter}
                             fps={props.config.fps}
                             bezier={bezier}
                             eyeShape={eyeShape}
                             reflection={reflectionRef.current}
-                            irisAdjustment={irisAdjustmentRef.current}
                             innerPath={innerPath}
                             skewTransform={irisMatrixTransform(target)}
                             transformDuration={

--- a/src/components/eye/eyeParts/InnerEye.tsx
+++ b/src/components/eye/eyeParts/InnerEye.tsx
@@ -3,11 +3,11 @@ import { connect } from 'react-redux';
 import tinycolor from 'tinycolor2';
 import { IRootStore } from '../../../store/reducers/rootReducer';
 import { getFPS } from '../../../store/selectors/configSelectors';
+import { ICoords } from '../../../utils/types';
 
 interface IInnerEyeProps {
     irisRadius: number;
-    innerY: number;
-    innerX: number;
+    innerCenter: ICoords;
     irisColor: string;
     innerPath: any;
     pupilRadius: number;
@@ -51,7 +51,7 @@ export const InnerEye = React.memo((props: InnerEyeProps) => {
         <g
             className="inner"
             style={transitionStyle}
-            transform={`${props.skewTransform} translate(${props.innerX},${props.innerY})`}
+            transform={`${props.skewTransform} translate(${props.innerCenter.x},${props.innerCenter.y})`}
         >
             <circle
                 className={'iris'}

--- a/src/components/eye/utils/VisualUtils.ts
+++ b/src/components/eye/utils/VisualUtils.ts
@@ -2,11 +2,6 @@ import { minIrisScale } from '../../../AppConstants';
 import { normalise } from '../../../utils/objectTracking/calculateFocus';
 import { ICoords } from '../../../utils/types';
 
-export interface IIrisAdjustment {
-    scale: number;
-    angle: number;
-}
-
 export function irisMatrixTransform(position: ICoords) {
     const radius = Math.hypot(position.x, position.y);
     if (radius === 0) {


### PR DESCRIPTION
This PR addresses #434 to remove unused props from `EyeController`. Upon closer inspection `detected` could not be removed as it reduces the number of calls to a `useEffect` hook. `irisAdjustment` was removed.

This PR also relates to the bigger goal of refactoring all of `EyeController` #344.

This PR is based on changes from #347 that refactor the `movementHander`.