### PR TITLE
Refactor/438 EyeController inner eye position

### DIFF
--- a/src/AppConstants.ts
+++ b/src/AppConstants.ts
@@ -79,7 +79,7 @@ export const targetingConsts = {
     maxInterval: 7000,
     maxNum: 8,
 };
-export const eyeRadiiCoefficients = {
+export const eyeCoefficients = {
     // multiple screen width by these values to get size of eye parts
     sclera: 1 / 4.5,
     iris: 1 / 10,

--- a/src/components/eye/utils/MovementUtils.ts
+++ b/src/components/eye/utils/MovementUtils.ts
@@ -1,8 +1,4 @@
-import {
-    eyeCoords,
-    idleMovementConsts,
-    lightConsts,
-} from '../../../AppConstants';
+import { lightConsts } from '../../../AppConstants';
 import { ICoords } from '../../../utils/types';
 
 export function analyseLight(image: ImageData): number {
@@ -21,34 +17,10 @@ export function analyseLight(image: ImageData): number {
     return Math.min(brightness, lightConsts.maxBrightness);
 }
 
-export function naturalMovement(currentX: number, isMovingLeft: boolean) {
-    const eyeBoundary = 1 - idleMovementConsts.sideBuffer;
-
-    if (currentX === eyeCoords.middleX) {
-        return Math.random() < idleMovementConsts.moveCenterChance
-            ? newEyePos(currentX, isMovingLeft)
-            : { newX: currentX, isMovingLeft };
-    } else if (Math.abs(currentX) >= eyeBoundary) {
-        return Math.random() < idleMovementConsts.moveSideChance
-            ? newEyePos(currentX, !isMovingLeft)
-            : { newX: currentX, isMovingLeft };
-    } else {
-        return newEyePos(currentX, isMovingLeft);
-    }
-}
-
-function newEyePos(currentX: number, isMovingLeft: boolean) {
-    let xDelta = idleMovementConsts.xDelta;
-    xDelta = isMovingLeft ? 0 - xDelta : xDelta;
-    return { newX: currentX + xDelta, isMovingLeft };
-}
-
 export function confineToCircle(target: ICoords) {
     const radius = Math.min(1, Math.hypot(target.x, target.y));
-    const polarAngle = Math.atan2(target.y, target.x);
 
-    return {
-        x: radius * Math.cos(polarAngle),
-        y: radius * Math.sin(polarAngle),
-    };
+    return radius === 0
+        ? { x: 0, y: 0 }
+        : { x: radius * (target.x / radius), y: radius * (target.y / radius) };
 }

--- a/src/components/eye/utils/MovementUtils.ts
+++ b/src/components/eye/utils/MovementUtils.ts
@@ -3,6 +3,7 @@ import {
     idleMovementConsts,
     lightConsts,
 } from '../../../AppConstants';
+import { ICoords } from '../../../utils/types';
 
 export function analyseLight(image: ImageData): number {
     if (!image) {
@@ -40,4 +41,14 @@ function newEyePos(currentX: number, isMovingLeft: boolean) {
     let xDelta = idleMovementConsts.xDelta;
     xDelta = isMovingLeft ? 0 - xDelta : xDelta;
     return { newX: currentX + xDelta, isMovingLeft };
+}
+
+export function confineToCircle(target: ICoords) {
+    const radius = Math.min(1, Math.hypot(target.x, target.y));
+    const polarAngle = Math.atan2(target.y, target.x);
+
+    return {
+        x: radius * Math.cos(polarAngle),
+        y: radius * Math.sin(polarAngle),
+    };
 }

--- a/src/components/eye/utils/MovementUtils.ts
+++ b/src/components/eye/utils/MovementUtils.ts
@@ -17,10 +17,9 @@ export function analyseLight(image: ImageData): number {
     return Math.min(brightness, lightConsts.maxBrightness);
 }
 
-export function confineToCircle(target: ICoords) {
-    const radius = Math.min(1, Math.hypot(target.x, target.y));
+export function confineToCircle(target: ICoords, radius: number = 1) {
+    const hypotenuse = Math.hypot(target.x, target.y);
+    const scale = hypotenuse > radius ? radius / hypotenuse : 1;
 
-    return radius === 0
-        ? { x: 0, y: 0 }
-        : { x: radius * (target.x / radius), y: radius * (target.y / radius) };
+    return { x: scale * target.x, y: scale * target.y };
 }

--- a/src/components/intelligentMovement/MovementHandler.tsx
+++ b/src/components/intelligentMovement/MovementHandler.tsx
@@ -139,10 +139,8 @@ export class MovementHandler extends React.Component<
     }
 
     checkSelection() {
-        if (
-            this.openCoefficient === eyelidPosition.SQUINT &&
-            Math.random() < 0.1
-        ) {
+        const isSquinting = this.openCoefficient === eyelidPosition.SQUINT;
+        if (isSquinting && Math.random() < 0.1) {
             this.openCoefficient = eyelidPosition.OPEN;
         }
 

--- a/src/components/intelligentMovement/MovementHandler.tsx
+++ b/src/components/intelligentMovement/MovementHandler.tsx
@@ -139,8 +139,10 @@ export class MovementHandler extends React.Component<
     }
 
     checkSelection() {
-        const isSquinting = this.openCoefficient === eyelidPosition.SQUINT;
-        if (isSquinting && Math.random() < 0.1) {
+        if (
+            this.openCoefficient === eyelidPosition.SQUINT &&
+            Math.random() < 0.1
+        ) {
             this.openCoefficient = eyelidPosition.OPEN;
         }
 


### PR DESCRIPTION
This PR addreses #438  to refactor the way the `target` and resulting inner eye position are calculated by the `EyeController`.

This also relates to #344 to clean up the `EyeController` overall.

This PR relies on PR #434, as these changes build on it.