### PR TITLE
Bug/478 local storage parsing

### DIFF
--- a/src/__tests__/store.test.tsx
+++ b/src/__tests__/store.test.tsx
@@ -1,17 +1,17 @@
-import { hasKeysOf } from '../store/store';
-describe('hasPropsOf', () => {
+import { hasPropertiesOf } from '../store/store';
+describe('hasPropertiesof', () => {
     it('should return true when objToMatch is empty object', () => {
         const objToCheck = { test: 'test', num: 5 };
-        expect(hasKeysOf(objToCheck, {})).toBeTruthy();
+        expect(hasPropertiesOf(objToCheck, {})).toBeTruthy();
     });
     const objToMatch = { a: 4, c: false };
     it('should return true when objToCheck has all keys of objToMatch', () => {
         const objToCheck = { a: 5, b: 'wee', c: false };
-        expect(hasKeysOf(objToCheck, objToMatch)).toBeTruthy();
+        expect(hasPropertiesOf(objToCheck, objToMatch)).toBeTruthy();
     });
     it('should return false when objToMatch has some key that objToCheck does not have', () => {
         const objToCheck = { a: 6, b: 'test', d: true };
-        expect(hasKeysOf(objToCheck, objToMatch)).toBeFalsy();
+        expect(hasPropertiesOf(objToCheck, objToMatch)).toBeFalsy();
     });
     const complexObjToMatch = {
         obj1: {
@@ -36,7 +36,7 @@ describe('hasPropsOf', () => {
             y: false,
             w: false,
         };
-        expect(hasKeysOf(objToCheck, complexObjToMatch)).toBeTruthy();
+        expect(hasPropertiesOf(objToCheck, complexObjToMatch)).toBeTruthy();
     });
     it('should return false when some child of objToMatch has a key which does not belong to that same child of objToCheck', () => {
         const objToCheck = {
@@ -50,6 +50,6 @@ describe('hasPropsOf', () => {
             y: false,
             w: false,
         };
-        expect(hasKeysOf(objToCheck, complexObjToMatch)).toBeFalsy();
+        expect(hasPropertiesOf(objToCheck, complexObjToMatch)).toBeFalsy();
     });
 });

--- a/src/__tests__/store.test.tsx
+++ b/src/__tests__/store.test.tsx
@@ -1,0 +1,55 @@
+import { hasKeysOf } from '../store/store';
+describe('hasPropsOf', () => {
+    it('should return true when objToMatch is empty object', () => {
+        const objToCheck = { test: 'test', num: 5 };
+        expect(hasKeysOf(objToCheck, {})).toBeTruthy();
+    });
+    const objToMatch = { a: 4, c: false };
+    it('should return true when objToCheck has all keys of objToMatch', () => {
+        const objToCheck = { a: 5, b: 'wee', c: false };
+        expect(hasKeysOf(objToCheck, objToMatch)).toBeTruthy();
+    });
+    it('should return false when objToMatch has some key that objToCheck does not have', () => {
+        const objToCheck = { a: 6, b: 'test', d: true };
+        expect(hasKeysOf(objToCheck, objToMatch)).toBeFalsy();
+    });
+    const complexObjToMatch = {
+        obj1: {
+            x: 5,
+            y: 6,
+        },
+        obj2: {
+            z: 6021830,
+        },
+        x: 'test',
+        y: 'haha',
+    };
+    it('should return true when objToKeys has all keys of objToMatch, and all object children of objToKeys have all keys of that same child of objToMatch', () => {
+        const objToCheck = {
+            obj1: {
+                x: 5,
+                y: 6,
+                z: 'test',
+            },
+            obj2: { z: 'test' },
+            x: 'test',
+            y: false,
+            w: false,
+        };
+        expect(hasKeysOf(objToCheck, complexObjToMatch)).toBeTruthy();
+    });
+    it('should return false when some child of objToMatch has a key which does not belong to that same child of objToCheck', () => {
+        const objToCheck = {
+            obj1: {
+                x: 5,
+                b: 6,
+                z: 'test',
+            },
+            obj2: { z: 'test' },
+            x: 'test',
+            y: false,
+            w: false,
+        };
+        expect(hasKeysOf(objToCheck, complexObjToMatch)).toBeFalsy();
+    });
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,16 +6,51 @@ import {
 } from 'redux';
 import { load, save } from 'redux-localstorage-simple';
 import thunk from 'redux-thunk';
+import { IConfigState } from './actions/config/types';
+import { initialState } from './reducers/configReducer';
 import reducer, { IRootStore } from './reducers/rootReducer';
 
 const states = ['configStore'];
 const middleware: Middleware[] = [thunk, save({ states })];
 
 export function createStore() {
+    const savedState: object | undefined = load({ states });
+    let savedStateIsValid;
+    if (savedState.hasOwnProperty('configStore')) {
+        const previousConfigState: IConfigState = (savedState as {
+            configStore: IConfigState;
+        }).configStore;
+        savedStateIsValid = hasKeysOfInitialConfigState(previousConfigState);
+    } else {
+        savedStateIsValid = false;
+    }
+
     return createReduxStore(
         reducer,
-        load({ states }),
+        savedStateIsValid ? savedState : undefined,
         applyMiddleware(...middleware),
+    );
+}
+
+export function hasKeysOfInitialConfigState(objToCheck: object) {
+    return hasKeysOf(objToCheck, initialState);
+}
+
+export function hasKeysOf(objToCheck: object, objToMatch: object): boolean {
+    const propsToCheck = Object.keys(objToCheck);
+    const propsToMatch = Object.keys(objToMatch);
+    return (
+        typeof objToCheck === 'string' ||
+        typeof objToMatch === 'string' || // prevents infinite recursion
+        propsToMatch.every(prop => {
+            return (
+                propsToCheck.indexOf(prop) >= 0 &&
+                hasKeysOf(
+                    (objToCheck as { [prop: string]: object })[prop],
+                    (objToMatch as { [prop: string]: object })[prop],
+                )
+            );
+        })
     );
 }
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -38,22 +38,24 @@ export function hasPropertiesOfInitialConfigState(objToCheck: object) {
     return hasPropertiesOf(objToCheck, initialState);
 }
 
-export function hasPropertiesOf(
-    objToCheck: object,
-    objWithRequiredProps: object,
-): boolean {
-    if (typeof objWithRequiredProps === 'string') {
+export function hasPropertiesOf(source: unknown, target: unknown): boolean {
+    if (typeof target !== 'object') {
         return true;
+    } else {
+        const requiredProps = Object.getOwnPropertyNames(target);
+        if (typeof source !== 'object') {
+            return requiredProps.length > 0;
+        } else {
+            return requiredProps.every(
+                prop =>
+                    (source as object).hasOwnProperty(prop) &&
+                    hasPropertiesOf(
+                        (source as { [prop: string]: unknown })[prop],
+                        (target as { [prop: string]: unknown })[prop],
+                    ),
+            );
+        }
     }
-    const requiredProps = Object.getOwnPropertyNames(objWithRequiredProps);
-    return requiredProps.every(
-        prop =>
-            objToCheck.hasOwnProperty(prop) &&
-            hasPropertiesOf(
-                (objToCheck as { [prop: string]: object })[prop],
-                (objWithRequiredProps as { [prop: string]: object })[prop],
-            ),
-    );
 }
 
 export type AppStore = Store<IRootStore>;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -20,7 +20,9 @@ export function createStore() {
         const previousConfigState: IConfigState = (savedState as {
             configStore: IConfigState;
         }).configStore;
-        savedStateIsValid = hasKeysOfInitialConfigState(previousConfigState);
+        savedStateIsValid = hasPropertiesOfInitialConfigState(
+            previousConfigState,
+        );
     } else {
         savedStateIsValid = false;
     }
@@ -32,25 +34,25 @@ export function createStore() {
     );
 }
 
-export function hasKeysOfInitialConfigState(objToCheck: object) {
-    return hasKeysOf(objToCheck, initialState);
+export function hasPropertiesOfInitialConfigState(objToCheck: object) {
+    return hasPropertiesOf(objToCheck, initialState);
 }
 
-export function hasKeysOf(objToCheck: object, objToMatch: object): boolean {
-    const propsToCheck = Object.keys(objToCheck);
-    const propsToMatch = Object.keys(objToMatch);
-    return (
-        typeof objToCheck === 'string' ||
-        typeof objToMatch === 'string' || // prevents infinite recursion
-        propsToMatch.every(prop => {
-            return (
-                propsToCheck.indexOf(prop) >= 0 &&
-                hasKeysOf(
-                    (objToCheck as { [prop: string]: object })[prop],
-                    (objToMatch as { [prop: string]: object })[prop],
-                )
-            );
-        })
+export function hasPropertiesOf(
+    objToCheck: object,
+    objWithRequiredProps: object,
+): boolean {
+    if (typeof objWithRequiredProps === 'string') {
+        return true;
+    }
+    const requiredProps = Object.getOwnPropertyNames(objWithRequiredProps);
+    return requiredProps.every(
+        prop =>
+            objToCheck.hasOwnProperty(prop) &&
+            hasPropertiesOf(
+                (objToCheck as { [prop: string]: object })[prop],
+                (objWithRequiredProps as { [prop: string]: object })[prop],
+            ),
     );
 }
 


### PR DESCRIPTION
Store will now compare the keys of the saved config to the keys of the initial config when loading from local storage. Ideally I would have liked to check that the saved config is an instance of the IConfigState interface, but interfaces cannot be used as such during run time. I'm very open to suggestions for ways to check if previousConfigState is an instance of IConfigState, as this current method doesn't feel very clean. IConfigState being a nested object makes things more complicated (i.e. can't just check if keys are subset of some set of keys)