### PR TITLE
Bug/524 Config Camera Disappear

### DIFF
--- a/src/components/configMenu/ConfigMenu.tsx
+++ b/src/components/configMenu/ConfigMenu.tsx
@@ -59,7 +59,10 @@ class ConfigMenu extends React.Component<ConfigMenuProps, IConfigMenuState> {
     mouseMoveHandler() {
         this.setState({ leftPosition: '0px' });
         this.props.window.clearInterval(this.hideTimeout);
-        if (!this.state.isUnderMouse && !this.props.config.toggleDebug) {
+        if (
+            !this.state.isUnderMouse &&
+            (!this.props.config.toggleDebug && this.props.config.toggleAdvanced)
+        ) {
             this.hideTimeout = this.props.window.setTimeout(
                 () =>
                     this.setState({


### PR DESCRIPTION
Config menu wasn't disappearing when camera feed was open even if advanced settings were closed.