### PR TITLE
Refactor/546 update outdated stream actions

### DIFF
--- a/src/__tests__/components/Video.test.tsx
+++ b/src/__tests__/components/Video.test.tsx
@@ -7,7 +7,6 @@ let props: VideoProps;
 describe('Video component tests', () => {
     beforeEach(() => {
         props = {
-            deviceId: 'testDevice',
             width: 100,
             height: 100,
             stream: (jest.fn() as unknown) as MediaStream,

--- a/src/__tests__/reducers/video/videoActions.test.ts
+++ b/src/__tests__/reducers/video/videoActions.test.ts
@@ -1,25 +1,25 @@
 import * as actions from '../../../store/actions/video/actions';
 import {
     SET_VIDEO,
-    SET_VIDEO_STREAMS,
+    SET_VIDEO_STREAM,
     TOGGLE_WEBCAM_AVAILABLE,
 } from '../../../store/actions/video/types';
-import { mockTwoVideoStreams } from './videoReducer.test';
 
 describe('Video Actions', () => {
     it('should create an action to add a video stream', () => {
+        const mockVideoStream = { width: 320, height: 640 };
         const expectedAction = {
-            type: SET_VIDEO_STREAMS,
-            payload: mockTwoVideoStreams,
+            type: SET_VIDEO_STREAM,
+            payload: mockVideoStream,
         };
-        expect(actions.setVideoStreamsAction(mockTwoVideoStreams)).toEqual(
+        expect(actions.setVideoStreamAction(mockVideoStream)).toEqual(
             expectedAction,
         );
     });
 
     it('should create an action to add a video html element', () => {
         const videoElement = document.createElement('video');
-        const payload = { deviceId: 'deviceId', video: videoElement };
+        const payload = videoElement;
 
         const expectedAction = {
             type: SET_VIDEO,

--- a/src/__tests__/reducers/video/videoReducer.test.ts
+++ b/src/__tests__/reducers/video/videoReducer.test.ts
@@ -2,14 +2,11 @@ import {
     IVideo,
     IVideoState,
     SET_VIDEO,
-    SET_VIDEO_STREAMS,
+    SET_VIDEO_STREAM,
     TOGGLE_WEBCAM_AVAILABLE,
     VideoAction,
 } from '../../../store/actions/video/types';
 import videoStore from '../../../store/reducers/videoReducer';
-
-export const testDevice1 = 'testDevice1';
-export const testDevice2 = 'testDevice2';
 
 const mockInitialState: IVideo = {
     width: 260,
@@ -27,7 +24,7 @@ describe('Video Reducer', () => {
     beforeEach(() => {
         mockStore = videoStore(
             { video, webcamAvailable: false, image: imgData },
-            { type: SET_VIDEO_STREAMS, payload: mockInitialState },
+            { type: SET_VIDEO_STREAM, payload: mockInitialState },
         );
     });
 
@@ -40,9 +37,9 @@ describe('Video Reducer', () => {
         expect(mockStore).toEqual(expectedState);
     });
 
-    it('should return a new state when dispaching Set Video Streams action', () => {
+    it('should return a new state when dispaching Set Video Stream action', () => {
         const newState = videoStore(mockStore, {
-            type: SET_VIDEO_STREAMS,
+            type: SET_VIDEO_STREAM,
             payload: mockInitialState,
         });
         const expectedState = {

--- a/src/__tests__/reducers/video/videoSelectors.test.ts
+++ b/src/__tests__/reducers/video/videoSelectors.test.ts
@@ -1,6 +1,6 @@
 import {
     IVideoState,
-    SET_VIDEO_STREAMS,
+    SET_VIDEO_STREAM,
 } from '../../../store/actions/video/types';
 import { initialConfig as initialConfigStore } from '../../../store/reducers/configReducer';
 import { initialState as initialDetectionStore } from '../../../store/reducers/detectionReducer';
@@ -24,7 +24,7 @@ describe('Video Selectors', () => {
     beforeEach(() => {
         mockVideoStore = videoStore(
             { video, webcamAvailable: false, image: imgData },
-            { type: SET_VIDEO_STREAMS, payload: device1 },
+            { type: SET_VIDEO_STREAM, payload: device1 },
         );
         mockRootStore = {
             videoStore: mockVideoStore,

--- a/src/components/eye/utils/ReflectionUtils.ts
+++ b/src/components/eye/utils/ReflectionUtils.ts
@@ -12,10 +12,6 @@ export function getReflection(
     if (!ctx) {
         return new ImageData(image.width, image.height);
     }
-    ctx.beginPath();
-    ctx.arc(radius, radius, radius, 0, Math.PI * 2, true);
-    ctx.closePath();
-    ctx.clip();
     const crop = getCrop(target, image);
     ctx.scale(-1, 1);
     const diameter = radius * 2;

--- a/src/components/video/Video.tsx
+++ b/src/components/video/Video.tsx
@@ -16,8 +16,7 @@ export function Video(props: VideoProps) {
     function getVideo(element: HTMLVideoElement | null) {
         if (element && props.stream) {
             element.srcObject = props.stream;
-            const payload = element;
-            props.setVideo(payload);
+            props.setVideo(element);
         }
     }
 

--- a/src/components/webcamHandler/WebcamHandler.ts
+++ b/src/components/webcamHandler/WebcamHandler.ts
@@ -1,4 +1,4 @@
-export async function configureStreams(mediaDevices: MediaDevices) {
+export async function configureStream(mediaDevices: MediaDevices) {
     try {
         const stream = await mediaDevices.getUserMedia({
             video: { width: 320, height: 240 },

--- a/src/store/actions/video/actions.ts
+++ b/src/store/actions/video/actions.ts
@@ -1,13 +1,13 @@
 import { Action } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
-import { configureStreams } from '../../../components/webcamHandler/WebcamHandler';
+import { configureStream } from '../../../components/webcamHandler/WebcamHandler';
 import { IRootStore } from '../../reducers/rootReducer';
 import { createAction, createActionPayload } from '../creators';
 import {
     IVideo,
     SET_IMAGE_DATA,
     SET_VIDEO,
-    SET_VIDEO_STREAMS,
+    SET_VIDEO_STREAM,
     TOGGLE_WEBCAM_AVAILABLE,
 } from './types';
 
@@ -16,15 +16,15 @@ export function setStream(mediaDevices: MediaDevices) {
         dispatch: ThunkDispatch<IRootStore, void, Action>,
         getState: () => IRootStore,
     ) => {
-        const streams = await configureStreams(mediaDevices);
-        const videoStore = getState().videoStore;
-        if (streams) {
-            dispatch(setVideoStreamsAction(streams));
-            if (!videoStore.webcamAvailable) {
+        const stream = await configureStream(mediaDevices);
+        const webcamAvailable = getState().videoStore.webcamAvailable;
+        if (stream) {
+            dispatch(setVideoStreamAction(stream));
+            if (!webcamAvailable) {
                 dispatch(toggleWebcamAvailable());
             }
         } else {
-            if (videoStore.webcamAvailable) {
+            if (webcamAvailable) {
                 dispatch(toggleWebcamAvailable());
             }
         }
@@ -36,10 +36,10 @@ export const setVideoAction = createActionPayload<
     HTMLVideoElement
 >(SET_VIDEO);
 
-export const setVideoStreamsAction = createActionPayload<
-    typeof SET_VIDEO_STREAMS,
+export const setVideoStreamAction = createActionPayload<
+    typeof SET_VIDEO_STREAM,
     IVideo
->(SET_VIDEO_STREAMS);
+>(SET_VIDEO_STREAM);
 
 export const toggleWebcamAvailable = createAction<
     typeof TOGGLE_WEBCAM_AVAILABLE

--- a/src/store/actions/video/types.ts
+++ b/src/store/actions/video/types.ts
@@ -1,20 +1,20 @@
 export const SET_VIDEO = 'SET_VIDEO';
-export const SET_VIDEO_STREAMS = 'SET_VIDEO_STREAMS';
+export const SET_VIDEO_STREAM = 'SET_VIDEO_STREAM';
 export const TOGGLE_WEBCAM_AVAILABLE = 'TOGGLE_WEBCAM_AVAILABLE';
 export const SET_IMAGE_DATA = 'SET_IMAGE_DATA';
 
 export enum VideoSetAction {
     VIDEO = 'SET_VIDEO',
-    VIDEO_STREAMS = 'SET_VIDEO_STREAMS',
+    VIDEO_STREAM = 'SET_VIDEO_STREAM',
     TOGGLE_WEBCAM = 'TOGGLE_WEBCAM_AVAILABLE',
     IMAGE_DATA = 'SET_IMAGE_DATA',
 }
 
 export interface IVideo {
-    videoElement?: HTMLVideoElement | undefined;
     width: number;
     height: number;
-    stream: MediaStream | undefined;
+    videoElement?: HTMLVideoElement;
+    stream?: MediaStream;
 }
 
 export interface IVideoState {
@@ -28,8 +28,8 @@ export interface ISetVideoAction {
     readonly payload: HTMLVideoElement;
 }
 
-export interface ISetVideoStreamsAction {
-    readonly type: typeof SET_VIDEO_STREAMS;
+export interface ISetVideoStreamAction {
+    readonly type: typeof SET_VIDEO_STREAM;
     readonly payload: IVideo;
 }
 
@@ -44,6 +44,6 @@ export interface ISetImageDataAction {
 
 export type VideoAction =
     | ISetVideoAction
-    | ISetVideoStreamsAction
+    | ISetVideoStreamAction
     | IToggleWebcamAvailable
     | ISetImageDataAction;

--- a/src/store/reducers/videoReducer.ts
+++ b/src/store/reducers/videoReducer.ts
@@ -1,7 +1,7 @@
 import {
     ISetImageDataAction,
     ISetVideoAction,
-    ISetVideoStreamsAction,
+    ISetVideoStreamAction,
     IVideoState,
     VideoAction,
     VideoSetAction,
@@ -19,7 +19,7 @@ const videoActionMapping = {
     [VideoSetAction.IMAGE_DATA]: setImageData,
     [VideoSetAction.TOGGLE_WEBCAM]: toggleWebcam,
     [VideoSetAction.VIDEO]: setVideo,
-    [VideoSetAction.VIDEO_STREAMS]: setVideoStreams,
+    [VideoSetAction.VIDEO_STREAM]: setVideoStream,
 };
 
 const videoStore = (
@@ -35,10 +35,10 @@ function setImageData(state: IVideoState, action: VideoAction): IVideoState {
     return { ...state, image: (action as ISetImageDataAction).payload };
 }
 
-function setVideoStreams(state: IVideoState, action: VideoAction): IVideoState {
+function setVideoStream(state: IVideoState, action: VideoAction): IVideoState {
     return {
         ...state,
-        video: { ...(action as ISetVideoStreamsAction).payload },
+        video: { ...(action as ISetVideoStreamAction).payload },
     };
 }
 


### PR DESCRIPTION
This PR addresses issue  #546 to remove outdated references to two camera support. This feature was removed, and the references have been updated to reflect that.